### PR TITLE
Can already throw error if "some" dependency is not a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
 function getDependencies(funcs) {
   const dependencies = Array.isArray(funcs[0]) ? funcs[0] : funcs
 
-  if (!dependencies.every(dep => typeof dep === 'function')) {
+  if (dependencies.some(dep => typeof dep !== 'function')) {
     const dependencyTypes = dependencies.map(
       dep => typeof dep
     ).join(', ')


### PR DESCRIPTION
If any dependency is not of type `function`, there is no need to check the rest of them, and we can already throw the error.