### PR TITLE
Pass all args to the selector function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,11 +49,11 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
       ...memoizeOptions
     )
 
-    const selector = (state, props, ...args) => {
+    const selector = (state, ...args) => {
       const params = dependencies.map(
-        dependency => dependency(state, props, ...args)
+        dependency => dependency(state, ...args)
       )
-      return memoizedResultFunc(...params)
+      return memoizedResultFunc(...params, ...args)
     }
 
     selector.recomputations = () => recomputations


### PR DESCRIPTION
Why do we have to special-case `props`? Let's pass all the arguments to the dependencies **and** to the result function. I'm still new to Reselect so I'm curious to know if I'm doing something wrong here.

This change will allow us to create selectors that take arguments:
```js
const allBooks = (state) => state.books;

const oldBooks = createSelector(
  [allBooks],
  (books, yearLimit) => books.filter(book => book.publishingYear < yearLimit)
);

oldBooks(state, 1990); // recomputation (initial computation)
oldBooks(state, 1990); // from cache

const booksByAuthorId = createSelector(
  [allBooks],
  (books, authorId) => books.find(book => book.authorId === authorId)
);

booksByAuthorId(state, 123); // recomputation (initial computation)
booksByAuthorId(state, 123); // from cache
```

It can be used with `react-redux` as follows:
```js
const mapStateToProps = (state, ownProps) => ({
  oldBooks: oldBooks(state, ownProps.yearLimit),
  booksByAuthorId: booksByAuthorId(state, ownProps.authorId),
});

const MyConnectedComponent = connect(mapStateToProps)(MyComponent);
```

See [my comments](https://github.com/reactjs/reselect/pull/59#issuecomment-196584574) for more context.