### PR TITLE
Add jsnext build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,12 +4,16 @@
     "transform-es2015-arrow-functions",
     "transform-es2015-block-scoping",
     "transform-es2015-function-name",
-    ["transform-es2015-modules-commonjs", { "loose": true }],
     "transform-es2015-parameters",
     "transform-es2015-spread",
     "transform-es2015-template-literals"
   ],
   "env": {
+    "commonjs": {
+      "plugins": [
+        ["transform-es2015-modules-commonjs", { "loose": true }]
+      ]
+    },
     "umd": {
       "plugins": [
         ["transform-es2015-modules-umd", { "loose": true }]
@@ -18,6 +22,7 @@
     },
     "test": {
       "plugins": [
+        ["transform-es2015-modules-commonjs", { "loose": true }],
         "transform-es2015-shorthand-properties"
       ]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ lib
 .nyc_output
 coverage
 dist
+es
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.4.0",
   "description": "Selectors for Redux.",
   "main": "lib/index.js",
-  "jsnext:main": "src/index.js",
+  "jsnext:main": "es/index.js",
   "typings": "src/reselect.d.ts",
   "files": [
     "lib",
@@ -14,10 +14,12 @@
     "url": "https://github.com/reactjs/reselect/issues"
   },
   "scripts": {
-    "compile": "babel -d lib/ src/ && cp ./src/reselect.d.ts lib",
+    "compile:commonjs": "NODE_ENV=commonjs babel -d lib/ src/ && cp ./src/reselect.d.ts lib",
     "compile:umd": "mkdir -p dist/ && NODE_ENV=umd babel -o dist/reselect.js src/",
+    "compile:es": "babel -d es/ src/",
+    "compile": "npm run compile:commonjs && npm run compile:umd && npm run compile:es",
     "lint": "eslint src test",
-    "prepublish": "npm run compile && npm run compile:umd",
+    "prepublish": "npm run compile",
     "test": "NODE_ENV=test mocha --compilers js:babel-register --recursive",
     "test:cov": "NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --compilers js:babel-register"
   },


### PR DESCRIPTION
Adds a build step for the `jsnext:main` which compiles all features _except_ for modules to an `es` folder.  The previous `compile` command is now the `commonjs` build which ends up in the `lib` directory.

Fixes #103