### PR TITLE
Add Node 6 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
       - "0.12"
       - "4"
       - "5"
+      - "6"
 script:
       - npm run lint
       - npm test


### PR DESCRIPTION
This adds Node v6 to the list of versions Travis will test against.