### PR TITLE
fix TS module resolution

### DIFF
--- a/src/reselect.d.ts
+++ b/src/reselect.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Frank Wallis <https://github.com/frankwallis>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-module Reselect {
+declare module Reselect {
 
     type Selector<TInput, TOutput> = (state: TInput, props?: any) => TOutput;
 

--- a/src/reselect.d.ts
+++ b/src/reselect.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Frank Wallis <https://github.com/frankwallis>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module Reselect {
+module Reselect {
 
     type Selector<TInput, TOutput> = (state: TInput, props?: any) => TOutput;
 
@@ -31,4 +31,6 @@ declare module Reselect {
     function createSelectorCreator(memoize: Memoizer, ...memoizeOptions: any[]): any;
 }
 
-export = Reselect;
+declare module "reselect" {
+  export = Reselect;
+}


### PR DESCRIPTION
I couldn't use npm Reselect typings as I do with eg Immutable.js
TS would not find the module.
It turns out you need to declare a module whose name match exactly the import's name, "" included.
I tested it, it works®

A good reference: https://github.com/facebook/immutable-js/blob/master/dist/immutable.d.ts