### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ So now `getVisibleTodos` has access to `props`, and everything seems to be worki
 
 **But there is a problem!**
 
-Using the `getVisibleTodos` selector with multiple instances of the `visibleTodoList` container will not correctly memoize:
+Using the `getVisibleTodos` selector with multiple instances of the `VisibleTodoList` container will not correctly memoize:
 
 #### `containers/VisibleTodoList.js`
 


### PR DESCRIPTION
Fixes a minor typo to capitalize `VisibleTodoList` in README.md: `visibleTodoList` -> `VisibleTodoList`