### PR TITLE
[Idea] Returning previous state from the previous selection - WIP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,43 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
     ) {
       return lastResult
     }
+    const veryLastArgs = lastArgs || [];
     lastArgs = args
-    lastResult = func(...args)
+    lastResult = func(...args, ...veryLastArgs, lastResult))
     return lastResult
   }
 }
+/*
+test('Test returning previous state', () => { 
+  const selector = createSelector(
+    [ state => state.a, state => state.b ],
+    (a, b, _a, _b, previous) => { 
+        console.log('RUN...')
+        console.log('current a', a);
+        console.log('previous _a', _a);
+        console.log('current b', b);
+        console.log('previous _b', _b);
+        console.log('previous result', previous);
+      return { c: a + b }
+    }
+  )
+})
+
+//Sample OUTPUT
+RUN...
+a 1
+_a undefined
+b 2
+_b undefined
+undefined
+
+RUN...
+a 3
+_a 1
+b 2
+_b 2
+{ c: 3 }
+*/
 
 function getDependencies(funcs) {
   const dependencies = Array.isArray(funcs[0]) ? funcs[0] : funcs


### PR DESCRIPTION
> NOTE, this is not the final PR, its just to start the discussion around the possibility of returning the previous state from the previous selection. This was spawned from a discussion the `reselect-map` repo - https://github.com/HeyImAlex/reselect-map/issues/1

In cases where you have large amounts of objects with the added need of complex transformations (see above issue), having to recalculate the whole object graph every time tends to become inefficient... For instance, if I have a collection in my state object which has got 5000 objects in it, and an action within the system causes one more item to be added to that list, all of my selectors have to be recalculated from scratch. In my case, the selectors are doing complex transformations on the data and most of the time, when new data comes in (data is always added, its never updated or removed), the resulting change only affects a small part of the "selected" object graph. The following is a sample of the problem:

```
// input
action.messages = [
    { id: 1, context: { id: 1, ... }, types: [ 'a', 'b' ], payload: { ... } }, 
    { id: 2, context: { id: 2, ... }, types: [ 'c' ], payload: { ... } }, 
    { id: 3, context: { id: 1, ... }, types: [ 'a' ], payload: { ... } }, 
    { id: 4, context: { id: 1, ... }, types: [ 'c' ], payload: { ... } }, 
    { id: 5, context: { id: 1, ... }, types: [ 'd' ], payload: { ... } }, 
    { id: 6, context: { id: 2, ... }, types: [ 'c' ], payload: { ... } }, 
    { id: 7, context: { id: 2, ... }, types: [ 'a' ], payload: { ... } }, 
];

// output
state = {
    listing: [ ... ], // Simple: Unique list of messages by message.id
    byId: { ... },   // Simple: Indexed messages by message.id
    byContextId: {
        1: {
            listing: [ ... ], // Unique list of messages by message.id where context.id = 1
            byType: {
                'a': [ .... ], // Unique list of messages by message.id where message.context.id = 1 and message.type = 'a'
                'b': [ .... ], // Unique list of messages by message.id where message.context.id = 1 and message.type = 'b'
                ...
            },
            ... // others here
        }
    }, // Harder: Grouped by message.context.id
    ...
}
```

Given this problem, I started looking at `reselect-map` but it doesn't have the ability to do the complex grouping that is required (again see referenced issue)... hence I started thinking about how this might be possible and most of the ideas tend to start with knowing what was the previous result and what was the previous arguments. This PR is the strawman of this idea... its data that the system already has, its just a matter of making it available.

The problem that still exists that I need to work out what actually changed (in my case, what message of the 5000 was actually added), but again this is the starting point and I'm open to ideas.

Its very possible that I'm thinking about this all wrong and if I am I'd love to hear how this could be done better.
