### PR TITLE
Issue/136 Support array argument for createSelector.

### DIFF
--- a/src/reselect.d.ts
+++ b/src/reselect.d.ts
@@ -20,11 +20,51 @@ declare module Reselect {
 
     function createSelector<
         TInput, TProps, TOutput,
+        T1
+    >(
+        selectors: [Selector<TInput, TProps, T1>],
+        combiner: (
+            arg1: T1
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
         T1,
         T2
     >(
         selector1: Selector<TInput, TProps, T1>,
         selector2: Selector<TInput, TProps, T2>,
+        combiner: (
+            arg1: T1,
+            arg2: T2
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2
@@ -51,6 +91,24 @@ declare module Reselect {
         TInput, TProps, TOutput,
         T1,
         T2,
+        T3
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
         T3,
         T4
     >(
@@ -58,6 +116,27 @@ declare module Reselect {
         selector2: Selector<TInput, TProps, T2>,
         selector3: Selector<TInput, TProps, T3>,
         selector4: Selector<TInput, TProps, T4>,
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2,
@@ -94,6 +173,30 @@ declare module Reselect {
         T2,
         T3,
         T4,
+        T5
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
         T5,
         T6
     >(
@@ -103,6 +206,33 @@ declare module Reselect {
         selector4: Selector<TInput, TProps, T4>,
         selector5: Selector<TInput, TProps, T5>,
         selector6: Selector<TInput, TProps, T6>,
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2,
@@ -149,6 +279,36 @@ declare module Reselect {
         T4,
         T5,
         T6,
+        T7
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
         T7,
         T8
     >(
@@ -160,6 +320,39 @@ declare module Reselect {
         selector6: Selector<TInput, TProps, T6>,
         selector7: Selector<TInput, TProps, T7>,
         selector8: Selector<TInput, TProps, T8>,
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2,
@@ -216,6 +409,42 @@ declare module Reselect {
         T6,
         T7,
         T8,
+        T9
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>,
+            Selector<TInput, TProps, T9>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8,
+            arg9: T9
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
         T9,
         T10
     >(
@@ -229,6 +458,45 @@ declare module Reselect {
         selector8: Selector<TInput, TProps, T8>,
         selector9: Selector<TInput, TProps, T9>,
         selector10: Selector<TInput, TProps, T10>,
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8,
+            arg9: T9,
+            arg10: T10
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>,
+            Selector<TInput, TProps, T9>,
+            Selector<TInput, TProps, T10>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2,
@@ -295,6 +563,48 @@ declare module Reselect {
         T8,
         T9,
         T10,
+        T11
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>,
+            Selector<TInput, TProps, T9>,
+            Selector<TInput, TProps, T10>,
+            Selector<TInput, TProps, T11>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8,
+            arg9: T9,
+            arg10: T10,
+            arg11: T11
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
         T11,
         T12
     >(
@@ -310,6 +620,51 @@ declare module Reselect {
         selector10: Selector<TInput, TProps, T10>,
         selector11: Selector<TInput, TProps, T11>,
         selector12: Selector<TInput, TProps, T12>,
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8,
+            arg9: T9,
+            arg10: T10,
+            arg11: T11,
+            arg12: T12
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>,
+            Selector<TInput, TProps, T9>,
+            Selector<TInput, TProps, T10>,
+            Selector<TInput, TProps, T11>,
+            Selector<TInput, TProps, T12>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2,
@@ -386,6 +741,54 @@ declare module Reselect {
         T10,
         T11,
         T12,
+        T13
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>,
+            Selector<TInput, TProps, T9>,
+            Selector<TInput, TProps, T10>,
+            Selector<TInput, TProps, T11>,
+            Selector<TInput, TProps, T12>,
+            Selector<TInput, TProps, T13>
+        ],
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8,
+            arg9: T9,
+            arg10: T10,
+            arg11: T11,
+            arg12: T12,
+            arg13: T13
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
         T13,
         T14
     >(
@@ -403,6 +806,57 @@ declare module Reselect {
         selector12: Selector<TInput, TProps, T12>,
         selector13: Selector<TInput, TProps, T13>,
         selector14: Selector<TInput, TProps, T14>,
+        combiner: (
+            arg1: T1,
+            arg2: T2,
+            arg3: T3,
+            arg4: T4,
+            arg5: T5,
+            arg6: T6,
+            arg7: T7,
+            arg8: T8,
+            arg9: T9,
+            arg10: T10,
+            arg11: T11,
+            arg12: T12,
+            arg13: T13,
+            arg14: T14
+        ) => TOutput
+    ): Selector<TInput, TProps, TOutput>;
+
+    function createSelector<
+        TInput, TProps, TOutput,
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14
+    >(
+        selectors: [
+            Selector<TInput, TProps, T1>,
+            Selector<TInput, TProps, T2>,
+            Selector<TInput, TProps, T3>,
+            Selector<TInput, TProps, T4>,
+            Selector<TInput, TProps, T5>,
+            Selector<TInput, TProps, T6>,
+            Selector<TInput, TProps, T7>,
+            Selector<TInput, TProps, T8>,
+            Selector<TInput, TProps, T9>,
+            Selector<TInput, TProps, T10>,
+            Selector<TInput, TProps, T11>,
+            Selector<TInput, TProps, T12>,
+            Selector<TInput, TProps, T13>,
+            Selector<TInput, TProps, T14>
+        ],
         combiner: (
             arg1: T1,
             arg2: T2,

--- a/src/reselect.d.ts
+++ b/src/reselect.d.ts
@@ -33,21 +33,6 @@ declare module Reselect {
         T1,
         T2
     >(
-        selectors: [
-            Selector<TInput, TProps, T1>,
-            Selector<TInput, TProps, T2>
-        ],
-        combiner: (
-            arg1: T1,
-            arg2: T2
-        ) => TOutput
-    ): Selector<TInput, TProps, TOutput>;
-
-    function createSelector<
-        TInput, TProps, TOutput,
-        T1,
-        T2
-    >(
         selector1: Selector<TInput, TProps, T1>,
         selector2: Selector<TInput, TProps, T2>,
         combiner: (

--- a/typescript_test/common.ts
+++ b/typescript_test/common.ts
@@ -1,22 +1,24 @@
 
 export type RootState = {
   items: {[key: string]: {
-    id: string
-  }}
+    id: string,
+  }},
 }
 
 export const rootState: RootState = {
   items: {
-    foo: {id:'abcd'}
-  }
+    foo: {id:'abcd'},
+  },
 };
 
 export type DeleteButtonStateProps = {
-  disabled: boolean
+  disabled: boolean,
 }
 
 export type DeleteButtonContainerProps = {
-  itemId: string
+  itemId: string,
 }
 
-export function selectorConsumer (selector: (state: RootState, props: DeleteButtonContainerProps) => DeleteButtonStateProps) {}
+export function selectorConsumer (
+  selector: (state: RootState, props: DeleteButtonContainerProps) => DeleteButtonStateProps
+) {}

--- a/typescript_test/should_compile/index.ts
+++ b/typescript_test/should_compile/index.ts
@@ -1,7 +1,6 @@
 import {createSelector} from '../../src/reselect.d.ts';
 import * as common from '../common';
 
-
 // Explicitly typed.
 const explicitlyTypedSelector = createSelector<
   common.RootState, common.DeleteButtonContainerProps, common.DeleteButtonStateProps,
@@ -9,7 +8,7 @@ const explicitlyTypedSelector = createSelector<
 > (
   (state, props) => !!state.items[props.itemId],
   (itemExists: boolean) => ({
-    disabled: !itemExists
+    disabled: !itemExists,
   })
 );
 common.selectorConsumer(explicitlyTypedSelector);
@@ -18,14 +17,13 @@ explicitlyTypedSelector(
   {
     itemId: 'abcd',
   }
-)
-
+);
 
 // Implicitly typed.
 const implicitlyTypedSelector = createSelector(
   (state: common.RootState, props: common.DeleteButtonContainerProps) => !!state.items[props.itemId],
   (itemExists: boolean) => ({
-    disabled: !itemExists
+    disabled: !itemExists,
   })
 );
 common.selectorConsumer(implicitlyTypedSelector);
@@ -34,4 +32,47 @@ implicitlyTypedSelector(
   {
     itemId: 'abcd',
   }
-)
+);
+
+// Array syntax
+const arrayType = createSelector(
+  [
+    (state: common.RootState, props: common.DeleteButtonContainerProps) => !!state.items[props.itemId],
+  ],
+  (itemExists: boolean) => ({
+    disabled: !itemExists,
+  })
+);
+common.selectorConsumer(arrayType);
+arrayType(
+  common.rootState,
+  {
+    itemId: 'abcd',
+  }
+);
+
+// Array syntax, 5 inputs
+// Allows for possible refactoring with upcoming TypeScript 2.1 object spread operator
+const arrayTypeFive = createSelector(
+  [
+    (state: common.RootState, props: common.DeleteButtonContainerProps) => !!state.items[props.itemId],
+    (state: common.RootState) => !!state.items,
+    (state: common.RootState) => state.items[0],
+    (state: common.RootState, props: common.DeleteButtonContainerProps) => state.items[props.itemId],
+    (state: common.RootState) => !!state.items[0],
+  ],
+  (a: boolean, b: boolean, c: {id: string}, d: {id: string}, e: boolean) => ({
+    a,
+    b,
+    c,
+    d,
+    e,
+  })
+);
+common.selectorConsumer(arrayType);
+arrayTypeFive(
+  common.rootState,
+  {
+    itemId: 'abcd',
+  }
+);

--- a/typescript_test/should_not_compile/index.ts
+++ b/typescript_test/should_not_compile/index.ts
@@ -1,11 +1,11 @@
-import {createSelector} from '../../../src/reselect.d.ts';
+import {createSelector} from '../../src/reselect.d.ts';
 import * as common from '../common';
 
 
 const implicitlyTypedSelector = createSelector(
   (state: common.RootState, props: common.DeleteButtonContainerProps) => !!state.items[props.itemId],
   (itemExists: boolean) => ({
-    disabled: !itemExists
+    disabled: !itemExists,
   })
 );
 
@@ -21,6 +21,28 @@ implicitlyTypedSelector(
   common.rootState,
   {
     itemId: 'abcd',
-    foo: 'bar'
+    foo: 'bar',
   }
+)
+
+// Array syntax - Return value of createSelector must match combiner function type
+createSelector(
+  [
+    (state: common.RootState) => state.items[0].id,
+    (state: common.RootState) => !!state.items[0].id,
+  ],
+  (id: boolean, exists: boolean) => ({
+    id,
+    exists,
+  })
+)
+
+// Array syntax - Return value of createSelector must match combiner function type
+createSelector(
+  (state: common.RootState) => state.items[0].id,
+  (state: common.RootState) => !!state.items[0].id,
+  (id: boolean, exists: boolean) => ({
+    id,
+    exists,
+  })
 )

--- a/typescript_test/test.js
+++ b/typescript_test/test.js
@@ -4,6 +4,7 @@ try {
   run('./node_modules/typescript/bin/tsc ./typescript_test/should_compile/index.ts')
 }
 catch(e) {
+  // eslint-disable-next-line no-console
   console.log('Typing error: valid typescript typings failed to compile')
   process.exit(1)
 }
@@ -15,5 +16,6 @@ catch(e) {
   process.exit(0)
 }
 
+// eslint-disable-next-line no-console
 console.log('Typing error: invalid typescript typings successfully compiled')
 process.exit(1)


### PR DESCRIPTION
Sadly, I can't find a way to support either format without duplicating the same approach taken for the multiple-argument signature. The definition file is now 10X bigger than the library itself. :(

Fix some eslint complaints.
Use trailing commas consistently.

It's possible there's a way to do this with `...args: Selector<>[]`, but I can't figure out how to preserve the selector / combiner return/argument pairing with that approach. Changes to Typescript 2.1 (supporting object spread) might open up some possibilities here.