### PR TITLE
Cancel args memorization if func throws exception

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
     ) {
       return lastResult
     }
-    lastArgs = args
     lastResult = func(...args)
+    lastArgs = args
     return lastResult
   }
 }

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -79,6 +79,36 @@ suite('selector', () => {
     )
     assert.equal(selector({ a: 1, b: 2 }, { c: 100 }), 103)
   })
+  test('recomputes result after exception', () => {
+    let called = 0;
+    const selector = createSelector(
+      state => state.a,
+      (a) => {
+        called++
+        throw Error('test error')
+      }
+    )
+    assert.throw(() => selector({ a: 1 }), 'test error')
+    assert.throw(() => selector({ a: 1 }), 'test error')
+    assert.equal(called, 2)
+  })
+  test('memoizes previous result before exception', () => {
+    let called = 0;
+    const selector = createSelector(
+      state => state.a,
+      (a) => {
+        called++
+        if (a > 1) throw Error('test error')
+        return a
+      }
+    )
+    const state1 = { a: 1 };
+    const state2 = { a: 2 };
+    assert.equal(selector(state1), 1)
+    assert.throw(() => selector(state2), 'test error')
+    assert.equal(selector(state1), 1)
+    assert.equal(called, 2)
+  })
   test('chained selector', () => { 
     const selector1 = createSelector(
       state => state.sub,

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -80,10 +80,10 @@ suite('selector', () => {
     assert.equal(selector({ a: 1, b: 2 }, { c: 100 }), 103)
   })
   test('recomputes result after exception', () => {
-    let called = 0;
+    let called = 0
     const selector = createSelector(
       state => state.a,
-      (a) => {
+      () => {
         called++
         throw Error('test error')
       }
@@ -93,7 +93,7 @@ suite('selector', () => {
     assert.equal(called, 2)
   })
   test('memoizes previous result before exception', () => {
-    let called = 0;
+    let called = 0
     const selector = createSelector(
       state => state.a,
       (a) => {
@@ -102,8 +102,8 @@ suite('selector', () => {
         return a
       }
     )
-    const state1 = { a: 1 };
-    const state2 = { a: 2 };
+    const state1 = { a: 1 }
+    const state2 = { a: 2 }
     assert.equal(selector(state1), 1)
     assert.throw(() => selector(state2), 'test error')
     assert.equal(selector(state1), 1)


### PR DESCRIPTION
The issue is when `func` throws exception the last `args` already saved and next calling of memoized func will return `null` instead of recalculating `func` again. If we save `args` after calling of `func` we save `args` only for "good" result and don't for exceptions.