### PR TITLE
Updated lodash memoized example function with initialValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,8 @@ import memoize from 'lodash.memoize'
 
 let called = 0
 const hashFn = (...args) => args.reduce(
-  (acc, val) => acc + '-' + JSON.stringify(val)
+  (acc, val) => acc + '-' + JSON.stringify(val),
+  ''
 )
 const customSelectorCreator = createSelectorCreator(memoize, hashFn)
 const selector = customSelectorCreator(


### PR DESCRIPTION
I think it is probably sensible to have an empty string as the `initialValue` of this example reducer, otherwise the first argument in the array is not stringified.

I know it's just an example, but as I'd copied and pasted this as a starting point for something a little more complicated I ran into some problems (which I traced back to this) and I'm guessing other people might do the same.

Cheers