### PR TITLE
Make defaultMemoizer store the latest args if the equality test passes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,13 +7,12 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   let lastResult = null
   return (...args) => {
     if (
-      lastArgs !== null &&
-      lastArgs.length === args.length &&
-      args.every((value, index) => equalityCheck(value, lastArgs[index]))
+      lastArgs === null ||
+      lastArgs.length !== args.length ||
+      !args.every((value, index) => equalityCheck(value, lastArgs[index]))
     ) {
-      return lastResult
+      lastResult = func(...args)
     }
-    lastResult = func(...args)
     lastArgs = args
     return lastResult
   }


### PR DESCRIPTION
Closes https://github.com/reactjs/reselect/issues/170

_For posterity_
Previously, not updating `lastArgs` when the equality test passed
meant that if an object goes from shallow equal -> deep equal ->
shallow equal accross updates, that transition back to shallow equal
would continue to require deep equality checks. This could lead
to large slowdowns for complex objects. See the github issue
for details.