### PR TITLE
Improve defaultMemoize performance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,12 @@ function defaultEqualityCheck(a, b) {
 export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   let lastArgs = null
   let lastResult = null
+  const isEqual = (value, index) => equalityCheck(value, lastArgs[index])
   return (...args) => {
     if (
       lastArgs === null ||
       lastArgs.length !== args.length ||
-      !args.every((value, index) => equalityCheck(value, lastArgs[index]))
+      !args.every(isEqual)
     ) {
       lastResult = func(...args)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,12 @@ function defaultEqualityCheck(a, b) {
 export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   let lastArgs = null
   let lastResult = null
-  const isEqual = (value, index) => equalityCheck(value, lastArgs[index])
+  const isEqualToLastArg = (value, index) => equalityCheck(value, lastArgs[index])
   return (...args) => {
     if (
       lastArgs === null ||
       lastArgs.length !== args.length ||
-      !args.every(isEqual)
+      !args.every(isEqualToLastArg)
     ) {
       lastResult = func(...args)
     }


### PR DESCRIPTION
`defaultMemoize` creates an unnecessary inline function on (nearly) every invocation of the returned function. This affects both speed and memory usage. The function has been moved to the outer scope.

A very simple benchmark shows ~ 30% perf improvement in Chrome and ~ 150% in Firefox: https://www.measurethat.net/Benchmarks/Show/259/9/reselect-defaultmemoize