### PR TITLE
Rename makeGetVisibleTodos example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ A selector created with `createSelector` only returns the cached value when its 
 
 To share a selector across multiple `VisibleTodoList` components while passing in `props` **and** retaining memoization, each instance of the component needs its own private copy of the selector.
 
-Let’s create a function named `makeGetVisibleTodos` that returns a new copy of the `getVisibleTodos` selector each time it is called:
+Let’s create a function named `makeVisibleTodosSelector` that returns a new copy of the `getVisibleTodos` selector each time it is called:
 
 #### `selectors/todoSelectors.js`
 
@@ -333,7 +333,7 @@ const getVisibilityFilter = (state, props) =>
 const getTodos = (state, props) =>
   state.todoLists[props.listId].todos
 
-const makeGetVisibleTodos = () => {
+const makeVisibleTodosSelector = () => {
   return createSelector(
     [ getVisibilityFilter, getTodos ],
     (visibilityFilter, todos) => {
@@ -344,12 +344,12 @@ const makeGetVisibleTodos = () => {
           return todos.filter(todo => !todo.completed)
         default:
           return todos
-      }
+        }
     }
   )
 }
 
-export default makeGetVisibleTodos
+export default makeVisibleTodosSelector
 ```
 
 We also need a way to give each instance of a container access to its own private selector. The `mapStateToProps` argument of `connect` can help with this.
@@ -360,7 +360,7 @@ In the example below `makeMapStateToProps` creates a new `getVisibleTodos` selec
 
 ```js
 const makeMapStateToProps = () => {
-  const getVisibleTodos = makeGetVisibleTodos()
+  const getVisibleTodos = makeVisibleTodosSelector()
   const mapStateToProps = (state, props) => {
     return {
       todos: getVisibleTodos(state, props)
@@ -378,10 +378,10 @@ If we pass `makeMapStateToProps` to `connect`, each instance of the `VisibleTodo
 import { connect } from 'react-redux'
 import { toggleTodo } from '../actions'
 import TodoList from '../components/TodoList'
-import { makeGetVisibleTodos } from '../selectors'
+import { makeVisibleTodosSelector } from '../selectors'
 
 const makeMapStateToProps = () => {
-  const getVisibleTodos = makeGetVisibleTodos()
+  const getVisibleTodos = makeVisibleTodosSelector()
   const mapStateToProps = (state, props) => {
     return {
       todos: getVisibleTodos(state, props)


### PR DESCRIPTION
Hi All! 👋

First off, thanks for the awesome work! 🙇

Some of us have been having a [discussion](https://github.com/mxstbr/react-boilerplate/pull/1205) over at React Boilerplate ([stemming from here](https://github.com/mxstbr/react-boilerplate/issues/882)).

>I'm not particularly sold on the naming: `makeSelectLocationState`.
I feel this is a little confusing since `make` & `select` are both verbs.

As you can see in the PR, I've pointed out that this function name starts with 2 verbs, which seems a little weird to me.

I thought I'd open this PR as a place to see what others (especially the authors) think about this naming and wether my suggestion, or an alternative, might make a little more sense :)

TIA ❤️