### PR TITLE
Remove excess asigment of lastArgs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,8 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
       !args.every(isEqualToLastArg)
     ) {
       lastResult = func(...args)
+      lastArgs = args
     }
-    lastArgs = args
     return lastResult
   }
 }


### PR DESCRIPTION
Assign ```lastArgs``` only if ```equalityCheck``` returns ```false```