### PR TITLE
Speedup cache hit performance of selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:cov": {
       "command": "nyc --reporter=lcov --reporter=text mocha --compilers js:babel-register --ui tdd",
       "env": {
-        "NODE_ENV": "test"
+        "NODE_ENV": "test",
+        "COVERAGE": "true"
       }
     },
     "test:typescript": {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ function areArgumentsShallowlyEqual(equalityCheck, prev, next) {
     return false
   }
 
+  // Do this in a for loop (and not a `forEach` or an `every`) so we can determine equality as fast as possible.
   const length = prev.length
   for (let i = 0; i < length; i++) {
     if (!equalityCheck(prev[i], next[i])) {
@@ -25,8 +26,10 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   let lastArgs = null
   let lastResult = null
 
+  // we reference arguments instead of spreading them for performance reasons
   return function () {
     if (!areArgumentsShallowlyEqual(equalityCheck, lastArgs, arguments)) {
+      // apply arguments instead of spreading for performance.
       lastResult = func.apply(null, arguments)
     }
 
@@ -60,6 +63,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
     const memoizedResultFunc = memoize(
       function () {
         recomputations++
+        // apply arguments instead of spreading for performance.
         return resultFunc.apply(null, arguments)
       },
       ...memoizeOptions
@@ -70,9 +74,11 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
       const length = dependencies.length
 
       for (let i = 0; i < length; i++) {
+        // apply arguments instead of spreading and mutate a local list of params for performance.
         params.push(dependencies[i].apply(null, arguments))
       }
 
+      // apply arguments instead of spreading for performance.
       return memoizedResultFunc.apply(null, params)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,6 @@ function defaultEqualityCheck(a, b) {
 }
 
 function areArgumentsShallowlyEqual(equalityCheck, prev, next) {
-  if (prev === next) {
-    return true
-  }
-
   if (prev === null || next === null || prev.length !== next.length) {
     return false
   }

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,8 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
       ...memoizeOptions
     )
 
-    function selector() {
+    // If a selector is called with the exact same arguments we don't need to traverse our dependencies again.
+    const selector = defaultMemoize(function () {
       const params = []
       const length = dependencies.length
 
@@ -80,7 +81,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
 
       // apply arguments instead of spreading for performance.
       return memoizedResultFunc.apply(null, params)
-    }
+    })
 
     selector.resultFunc = resultFunc
     selector.recomputations = () => recomputations

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -41,6 +41,10 @@ suite('selector', () => {
     ), /input-selectors to be functions.*function, string/)
   })
   test('basic selector cache hit performance', () => {
+    if (process.env.COVERAGE) {
+      return // don't run performance tests for coverage
+    }
+
     const selector = createSelector(
       state => state.a,
       state => state.b,

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -6,8 +6,8 @@ import {  default as lodashMemoize  } from 'lodash.memoize'
 
 const assert = chai.assert
 
-suite('selector', () => { 
-  test('basic selector', () => { 
+suite('selector', () => {
+  test('basic selector', () => {
     const selector = createSelector(
       state => state.a,
       a => a
@@ -18,7 +18,7 @@ suite('selector', () => {
     assert.equal(selector({ a: 2 }), 2)
     assert.equal(selector.recomputations(), 2)
   })
-  test('basic selector multiple keys', () => { 
+  test('basic selector multiple keys', () => {
     const selector = createSelector(
       state => state.a,
       state => state.b,
@@ -33,14 +33,36 @@ suite('selector', () => {
     assert.equal(selector(state2), 5)
     assert.equal(selector.recomputations(), 2)
   })
-  test('basic selector invalid input selector', () => { 
+  test('basic selector invalid input selector', () => {
     assert.throw(() => createSelector(
       state => state.a,
       'not a function',
       (a, b) => a + b
     ), /input-selectors to be functions.*function, string/)
   })
-  test('memoized composite arguments', () => { 
+  test('basic selector cache hit performance', () => {
+    const selector = createSelector(
+      state => state.a,
+      state => state.b,
+      (a, b) => a + b
+    )
+    const state1 = { a: 1, b: 2 }
+
+    const start = new Date()
+    for (let i = 0; i < 1000000; i++) {
+      selector(state1)
+    }
+    const totalTime = new Date() - start
+
+    assert.equal(selector(state1), 3)
+    assert.equal(selector.recomputations(), 1)
+    assert.isBelow(
+      totalTime,
+      1000,
+      'Expected a million calls to a selector with the same arguments to take less than 1 second'
+    )
+  })
+  test('memoized composite arguments', () => {
     const selector = createSelector(
       state => state.sub,
         sub => sub
@@ -53,10 +75,10 @@ suite('selector', () => {
     assert.deepEqual(selector(state2), {  a: 2  })
     assert.equal(selector.recomputations(), 2)
   })
-  test('first argument can be an array', () => { 
+  test('first argument can be an array', () => {
     const selector = createSelector(
       [ state => state.a, state => state.b ],
-      (a, b) => { 
+      (a, b) => {
         return a + b
       }
     )
@@ -66,13 +88,13 @@ suite('selector', () => {
     assert.equal(selector({ a: 3, b: 2 }), 5)
     assert.equal(selector.recomputations(), 2)
   })
-  test('can accept props', () => { 
+  test('can accept props', () => {
     let called = 0
     const selector = createSelector(
       state => state.a,
       state => state.b,
       (state, props) => props.c,
-      (a, b, c) => { 
+      (a, b, c) => {
         called++
         return a + b + c
       }
@@ -109,7 +131,7 @@ suite('selector', () => {
     assert.equal(selector(state1), 1)
     assert.equal(called, 2)
   })
-  test('chained selector', () => { 
+  test('chained selector', () => {
     const selector1 = createSelector(
       state => state.sub,
       sub => sub
@@ -126,7 +148,7 @@ suite('selector', () => {
     assert.equal(selector2(state2), 2)
     assert.equal(selector2.recomputations(), 2)
   })
-  test('chained selector with props', () => { 
+  test('chained selector with props', () => {
     const selector1 = createSelector(
       state => state.sub,
       (state, props) => props.x,
@@ -145,7 +167,7 @@ suite('selector', () => {
     assert.equal(selector2(state2, { x: 100, y: 201 }), 303)
     assert.equal(selector2.recomputations(), 2)
   })
-  test('chained selector with variadic args', () => { 
+  test('chained selector with variadic args', () => {
     const selector1 = createSelector(
       state => state.sub,
       (state, props, another) => props.x + another,
@@ -164,7 +186,7 @@ suite('selector', () => {
     assert.equal(selector2(state2, { x: 100, y: 201 }, 200), 503)
     assert.equal(selector2.recomputations(), 2)
   })
-  test('override valueEquals', () => { 
+  test('override valueEquals', () => {
     // a rather absurd equals operation we can verify in tests
     const createOverridenSelector = createSelectorCreator(
       defaultMemoize,
@@ -180,10 +202,10 @@ suite('selector', () => {
     assert.equal(selector({ a: 'A' }), 'A')
     assert.equal(selector.recomputations(), 2)
   })
-  test('custom memoize', () => { 
+  test('custom memoize', () => {
     const hashFn = (...args) => args.reduce((acc, val) => acc + '-' + JSON.stringify(val))
     const customSelectorCreator = createSelectorCreator(
-      lodashMemoize, 
+      lodashMemoize,
       hashFn
     )
     const selector = customSelectorCreator(
@@ -202,9 +224,9 @@ suite('selector', () => {
     assert.equal(selector.recomputations(), 3)
     // TODO: Check correct memoize function was called
   })
-  test('exported memoize', () => { 
+  test('exported memoize', () => {
     let called = 0
-    const memoized = defaultMemoize(state => { 
+    const memoized = defaultMemoize(state => {
       called++
       return state.a
     })
@@ -222,12 +244,12 @@ suite('selector', () => {
     assert.equal(memoized(1, 2), 3)
     assert.equal(memoized(1), 1)
   })
-  test('exported memoize with valueEquals override', () => { 
+  test('exported memoize with valueEquals override', () => {
     // a rather absurd equals operation we can verify in tests
     let called = 0
     const valueEquals = (a, b) => typeof a === typeof b
     const memoized = defaultMemoize(
-      a => { 
+      a => {
         called++
         return a
       },
@@ -239,8 +261,8 @@ suite('selector', () => {
     assert.equal(memoized('A'), 'A')
     assert.equal(called, 2)
   })
-  test('structured selector', () => { 
-    const selector = createStructuredSelector({ 
+  test('structured selector', () => {
+    const selector = createStructuredSelector({
       x: state => state.a,
       y: state => state.b
     })
@@ -251,22 +273,22 @@ suite('selector', () => {
     assert.deepEqual(secondResult, { x: 2, y: 2 })
     assert.strictEqual(selector({ a: 2, b: 2 }), secondResult)
   })
-  test('structured selector with invalid arguments', () => { 
+  test('structured selector with invalid arguments', () => {
     assert.throw(() => createStructuredSelector(
       state => state.a,
       state => state.b
     ), /expects first argument to be an object.*function/)
-    assert.throw(() => createStructuredSelector({ 
+    assert.throw(() => createStructuredSelector({
       a: state => state.b,
       c: 'd'
     }), /input-selectors to be functions.*function, string/)
   })
-  test('structured selector with custom selector creator', () => { 
+  test('structured selector with custom selector creator', () => {
     const customSelectorCreator = createSelectorCreator(
       defaultMemoize,
       (a, b) => a === b
     )
-    const selector = createStructuredSelector({ 
+    const selector = createStructuredSelector({
       x: state => state.a,
       y: state => state.b
     }, customSelectorCreator)

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -20,10 +20,16 @@ suite('selector', () => {
       state => state.a,
       a => a
     )
-    assert.equal(selector({ a: 1 }), 1)
-    assert.equal(selector({ a: 1 }), 1)
+    const firstState = { a: 1 }
+    const firstStateNewPointer = { a: 1 }
+    const secondState = { a: 2 }
+    
+    assert.equal(selector(firstState), 1)
+    assert.equal(selector(firstState), 1)
     assert.equal(selector.recomputations(), 1)
-    assert.equal(selector({ a: 2 }), 2)
+    assert.equal(selector(firstStateNewPointer), 1)
+    assert.equal(selector.recomputations(), 1)
+    assert.equal(selector(secondState), 2)
     assert.equal(selector.recomputations(), 2)
   })
   test('basic selector multiple keys', () => {


### PR DESCRIPTION
ES6, object/array spreading and the like make the code much more readable and easier 
to reason about.

However, this trade-off comes at the cost of performance. When running a selector, a copy of the
parameters were cloned many times which added a trivial amount of overhead for a single call. 
However if a selector was called thousands of times (e.x. a large list of items) then the trivial
amount of overhead added upwards of around 1 second to all selector calls regardless of cache
hits/misses.

Normally, readable code > super optimized code but selectors can be called very often and the
overhead associated with those calls has to be minimal.

The first commit in this PR adds a test that calls a basic selector a million times. Before the
performance increase it takes ~2.5 seconds on my machine. Afterwards it takes ~140 milliseconds.