### PR TITLE
cacheSize option for defaultMemoize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ function defaultEqualityCheck(a, b) {
   return a === b
 }
 
-export function defaultMemoize(func, equalityCheck = defaultEqualityCheck, size=1) {
+export function defaultMemoize(func, equalityCheck = defaultEqualityCheck, cacheSize=1) {
 
   let cacheArgsArr = []     // Cache store of old argument arrays
   let cacheResultArr = []  // Cache store of old results
@@ -28,20 +28,20 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck, size=
       cacheArgsArr = [
         args,
         ...cacheArgsArr.slice( 0, foundIdx ),
-        ...cacheArgsArr.slice( foundIdx+1, size )
+        ...cacheArgsArr.slice( foundIdx+1, cacheSize )
       ]
       cacheResultArr = [
         cacheResultArr[foundIdx],
         ...cacheResultArr.slice( 0, foundIdx ),
-        ...cacheResultArr.slice( foundIdx+1, size )
+        ...cacheResultArr.slice( foundIdx+1, cacheSize )
       ]
       result = cacheResultArr[0]
 
     } else if( ! isFound ) {
 
       result = func(...args)
-      cacheArgsArr = [ args, ...cacheArgsArr.slice( 0, size-1 ) ]
-      cacheResultArr = [ result, ...cacheResultArr.slice( 0, size-1 ) ]
+      cacheArgsArr = [ args, ...cacheArgsArr.slice( 0, cacheSize-1 ) ]
+      cacheResultArr = [ result, ...cacheResultArr.slice( 0, cacheSize-1 ) ]
       result = cacheResultArr[0]
     }
 
@@ -54,7 +54,7 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck, size=
     return result
   }
 
-  memoizedResultFunc.getCacheArgArr = ()=> cacheArgsArr
+  memoizedResultFunc.getCacheArgsArr = ()=> cacheArgsArr
   memoizedResultFunc.getCacheResultArr = ()=> cacheResultArr
   memoizedResultFunc.clearCache = ()=> {
     cacheArgsArr = []
@@ -104,7 +104,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
     selector.resultFunc = resultFunc
     selector.recomputations = () => recomputations
     selector.resetRecomputations = () => recomputations = 0
-    selector.getCacheArgArr = () => memoizedResultFunc.getCacheArgArr()
+    selector.getCacheArgsArr = () => memoizedResultFunc.getCacheArgsArr()
     selector.getCacheResultArr = () => memoizedResultFunc.getCacheResultArr()
     selector.clearCache = () => memoizedResultFunc.clearCache()
     return selector

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -356,8 +356,8 @@ suite('selector', () => {
     assert.equal(powerSelector({ num: 4 }), 16) // expect recomputation
     assert.equal(powerSelector.recomputations(), 4)
     
-    assert.equal(powerSelector.getCacheArgArr()[0], 4)
-    assert.equal(powerSelector.getCacheArgArr()[1], 3)
+    assert.equal(powerSelector.getCacheArgsArr()[0], 4)
+    assert.equal(powerSelector.getCacheArgsArr()[1], 3)
 
     assert.equal(powerSelector({ num: 4 }), 16) // expect cache
     assert.equal(powerSelector({ num: 4 }), 16) // expect cache
@@ -370,9 +370,9 @@ suite('selector', () => {
     assert.equal(powerSelector({ num: 4 }), 16) // expect cache
 
     assert.equal(powerSelector.recomputations(), 6)
-    assert.equal(powerSelector.getCacheArgArr().length, 2 )
+    assert.equal(powerSelector.getCacheArgsArr().length, 2 )
   })
-  test('defaultMemoize udpatedCache with cache size option', () => {
+  test('defaultMemoize updatedCache with cache size option', () => {
     const createSelectorWithCacheSize5 = createSelectorCreator( defaultMemoize, void 0, 5 )
 
     const powerSelector = createSelectorWithCacheSize5([
@@ -385,42 +385,42 @@ suite('selector', () => {
     assert.equal(powerSelector({ num: 4 }), 16) // expect recomputation
     assert.equal(powerSelector({ num: 5 }), 25) // expect recomputation
 
-    assert.equal(powerSelector.getCacheArgArr()[0], 5)
-    assert.equal(powerSelector.getCacheArgArr()[1], 4)
-    assert.equal(powerSelector.getCacheArgArr()[2], 3)
-    assert.equal(powerSelector.getCacheArgArr()[3], 2)
-    assert.equal(powerSelector.getCacheArgArr()[4], 1)
+    assert.equal(powerSelector.getCacheArgsArr()[0], 5)
+    assert.equal(powerSelector.getCacheArgsArr()[1], 4)
+    assert.equal(powerSelector.getCacheArgsArr()[2], 3)
+    assert.equal(powerSelector.getCacheArgsArr()[3], 2)
+    assert.equal(powerSelector.getCacheArgsArr()[4], 1)
 
     assert.equal(powerSelector({ num: 2 }), 4)  // expect cache
-    assert.equal(powerSelector.getCacheArgArr()[0], 2)
-    assert.equal(powerSelector.getCacheArgArr()[1], 5)
-    assert.equal(powerSelector.getCacheArgArr()[2], 4)
-    assert.equal(powerSelector.getCacheArgArr()[3], 3)
-    assert.equal(powerSelector.getCacheArgArr()[4], 1)
+    assert.equal(powerSelector.getCacheArgsArr()[0], 2)
+    assert.equal(powerSelector.getCacheArgsArr()[1], 5)
+    assert.equal(powerSelector.getCacheArgsArr()[2], 4)
+    assert.equal(powerSelector.getCacheArgsArr()[3], 3)
+    assert.equal(powerSelector.getCacheArgsArr()[4], 1)
 
     assert.equal(powerSelector({ num: 6 }), 36) // expect recomputation
-    assert.equal(powerSelector.getCacheArgArr()[0], 6)
-    assert.equal(powerSelector.getCacheArgArr()[1], 2)
-    assert.equal(powerSelector.getCacheArgArr()[2], 5)
-    assert.equal(powerSelector.getCacheArgArr()[3], 4)
-    assert.equal(powerSelector.getCacheArgArr()[4], 3)
-    assert.equal(powerSelector.getCacheArgArr()[5], void 0)
+    assert.equal(powerSelector.getCacheArgsArr()[0], 6)
+    assert.equal(powerSelector.getCacheArgsArr()[1], 2)
+    assert.equal(powerSelector.getCacheArgsArr()[2], 5)
+    assert.equal(powerSelector.getCacheArgsArr()[3], 4)
+    assert.equal(powerSelector.getCacheArgsArr()[4], 3)
+    assert.equal(powerSelector.getCacheArgsArr()[5], void 0)
 
     assert.equal(powerSelector({ num: 1 }), 1)  // expect recomputation
-    assert.equal(powerSelector.getCacheArgArr()[0], 1)
-    assert.equal(powerSelector.getCacheArgArr()[1], 6)
-    assert.equal(powerSelector.getCacheArgArr()[2], 2)
-    assert.equal(powerSelector.getCacheArgArr()[3], 5)
-    assert.equal(powerSelector.getCacheArgArr()[4], 4)
-    assert.equal(powerSelector.getCacheArgArr()[5], void 0)
+    assert.equal(powerSelector.getCacheArgsArr()[0], 1)
+    assert.equal(powerSelector.getCacheArgsArr()[1], 6)
+    assert.equal(powerSelector.getCacheArgsArr()[2], 2)
+    assert.equal(powerSelector.getCacheArgsArr()[3], 5)
+    assert.equal(powerSelector.getCacheArgsArr()[4], 4)
+    assert.equal(powerSelector.getCacheArgsArr()[5], void 0)
 
     assert.equal(powerSelector({ num: 1 }), 1)  // expect cache
-    assert.equal(powerSelector.getCacheArgArr()[0], 1)
-    assert.equal(powerSelector.getCacheArgArr()[1], 6)
-    assert.equal(powerSelector.getCacheArgArr()[2], 2)
-    assert.equal(powerSelector.getCacheArgArr()[3], 5)
-    assert.equal(powerSelector.getCacheArgArr()[4], 4)
-    assert.equal(powerSelector.getCacheArgArr()[5], void 0)
+    assert.equal(powerSelector.getCacheArgsArr()[0], 1)
+    assert.equal(powerSelector.getCacheArgsArr()[1], 6)
+    assert.equal(powerSelector.getCacheArgsArr()[2], 2)
+    assert.equal(powerSelector.getCacheArgsArr()[3], 5)
+    assert.equal(powerSelector.getCacheArgsArr()[4], 4)
+    assert.equal(powerSelector.getCacheArgsArr()[5], void 0)
 
     assert.equal(powerSelector.recomputations(), 7)
   })

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -342,4 +342,86 @@ suite('selector', () => {
     )
     assert.equal(selector.resultFunc, lastFunction)
   })
+  test('defaultMemoize recomputations with cache size option', () => {
+
+    const createSelectorWithCacheSize2 = createSelectorCreator( defaultMemoize, void 0, 2 )
+
+    const powerSelector = createSelectorWithCacheSize2([
+      (state)=>state.num
+    ], ( num )=> num*num )
+
+    assert.equal(powerSelector({ num: 1 }), 1)  // expect recomputation
+    assert.equal(powerSelector({ num: 2 }), 4)  // expect recomputation
+    assert.equal(powerSelector({ num: 3 }), 9)  // expect recomputation
+    assert.equal(powerSelector({ num: 4 }), 16) // expect recomputation
+    assert.equal(powerSelector.recomputations(), 4)
+    
+    assert.equal(powerSelector.getCacheArgArr()[0], 4)
+    assert.equal(powerSelector.getCacheArgArr()[1], 3)
+
+    assert.equal(powerSelector({ num: 4 }), 16) // expect cache
+    assert.equal(powerSelector({ num: 4 }), 16) // expect cache
+    assert.equal(powerSelector({ num: 3 }), 9)  // expect cache
+    assert.equal(powerSelector({ num: 3 }), 9)  // expect cache
+    assert.equal(powerSelector({ num: 2 }), 4)  // expect recomputation
+    assert.equal(powerSelector.recomputations(), 5)
+
+    assert.equal(powerSelector({ num: 4 }), 16) // expect recomputation
+    assert.equal(powerSelector({ num: 4 }), 16) // expect cache
+
+    assert.equal(powerSelector.recomputations(), 6)
+    assert.equal(powerSelector.getCacheArgArr().length, 2 )
+  })
+  test('defaultMemoize udpatedCache with cache size option', () => {
+    const createSelectorWithCacheSize5 = createSelectorCreator( defaultMemoize, void 0, 5 )
+
+    const powerSelector = createSelectorWithCacheSize5([
+      (state)=>state.num
+    ], ( num )=> num*num )
+
+    assert.equal(powerSelector({ num: 1 }), 1)  // expect recomputation
+    assert.equal(powerSelector({ num: 2 }), 4)  // expect recomputation
+    assert.equal(powerSelector({ num: 3 }), 9)  // expect recomputation
+    assert.equal(powerSelector({ num: 4 }), 16) // expect recomputation
+    assert.equal(powerSelector({ num: 5 }), 25) // expect recomputation
+
+    assert.equal(powerSelector.getCacheArgArr()[0], 5)
+    assert.equal(powerSelector.getCacheArgArr()[1], 4)
+    assert.equal(powerSelector.getCacheArgArr()[2], 3)
+    assert.equal(powerSelector.getCacheArgArr()[3], 2)
+    assert.equal(powerSelector.getCacheArgArr()[4], 1)
+
+    assert.equal(powerSelector({ num: 2 }), 4)  // expect cache
+    assert.equal(powerSelector.getCacheArgArr()[0], 2)
+    assert.equal(powerSelector.getCacheArgArr()[1], 5)
+    assert.equal(powerSelector.getCacheArgArr()[2], 4)
+    assert.equal(powerSelector.getCacheArgArr()[3], 3)
+    assert.equal(powerSelector.getCacheArgArr()[4], 1)
+
+    assert.equal(powerSelector({ num: 6 }), 36) // expect recomputation
+    assert.equal(powerSelector.getCacheArgArr()[0], 6)
+    assert.equal(powerSelector.getCacheArgArr()[1], 2)
+    assert.equal(powerSelector.getCacheArgArr()[2], 5)
+    assert.equal(powerSelector.getCacheArgArr()[3], 4)
+    assert.equal(powerSelector.getCacheArgArr()[4], 3)
+    assert.equal(powerSelector.getCacheArgArr()[5], void 0)
+
+    assert.equal(powerSelector({ num: 1 }), 1)  // expect recomputation
+    assert.equal(powerSelector.getCacheArgArr()[0], 1)
+    assert.equal(powerSelector.getCacheArgArr()[1], 6)
+    assert.equal(powerSelector.getCacheArgArr()[2], 2)
+    assert.equal(powerSelector.getCacheArgArr()[3], 5)
+    assert.equal(powerSelector.getCacheArgArr()[4], 4)
+    assert.equal(powerSelector.getCacheArgArr()[5], void 0)
+
+    assert.equal(powerSelector({ num: 1 }), 1)  // expect cache
+    assert.equal(powerSelector.getCacheArgArr()[0], 1)
+    assert.equal(powerSelector.getCacheArgArr()[1], 6)
+    assert.equal(powerSelector.getCacheArgArr()[2], 2)
+    assert.equal(powerSelector.getCacheArgArr()[3], 5)
+    assert.equal(powerSelector.getCacheArgArr()[4], 4)
+    assert.equal(powerSelector.getCacheArgArr()[5], void 0)
+
+    assert.equal(powerSelector.recomputations(), 7)
+  })
 })


### PR DESCRIPTION
As 3rd argument, now defaultMemoize() can get the `cacheSize`.

There are two arrays to store previous argument arrays, previous results.
```
let cacheArgsArr = []
let cacheREsultArr = []
```

`cacheSize` feature is designed as follows:

```
const createSelector = createSelectorCreator( defaultMemoize, void 0, 2 )
const powerSelector = createSelector([
      (state)=>state.num
], ( num )=> num*num )

console.log( powerSelector({ num: 1 }) )            // 1 (recomputation)
console.log( powerSelector.getCacheArgsArr() )      // [ [1] ]
console.log( powerSelector.getCacheResultArr() )    // [1]

console.log( powerSelector({ num: 2 }) )            // 4 (recomputation)
console.log( powerSelector.getCacheArgsArr() )      // [ [2],[1] ]
console.log( powerSelector.getCacheResultArr() )    // [ 4, 1 ]

console.log( powerSelector({ num: 3 }) )            // 9 (recomputation)
console.log( powerSelector.getCacheArgsArr() )      // [ [3],[2] ]
console.log( powerSelector.getCacheResultArr() )    // [ 9, 4 ]

console.log( powerSelector({ num: 2 }) )            // 4 (cache)
console.log( powerSelector.getCacheArgsArr() )      // [ [2],[3] ]
console.log( powerSelector.getCacheResultArr() )    // [ 4, 9 ]
```

In general, there is high a probability that last argument is used again.
So last arguemnts and result are added or updated to index: 0 in cacheArgsArr` and `cacheResultArr`

Please feel free to contact us if you have something lacking.