### PR TITLE
cache the subsets of a collection when the other parts changes cause the collection reference change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,20 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   let lastResult = null
   const isEqualToLastArg = (value, index) => equalityCheck(value, lastArgs[index])
   return (...args) => {
+    let tempResult = null
+
     if (
       lastArgs === null ||
       lastArgs.length !== args.length ||
       !args.every(isEqualToLastArg)
     ) {
-      lastResult = func(...args)
+      tempResult = func(...args)
+
+      if (!lastResult) {
+        lastResult = tempResult
+      } else if (!equalityCheck(tempResult, lastResult)) {
+        lastResult = tempResult
+      }
     }
     lastArgs = args
     return lastResult

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -278,6 +278,36 @@ suite('selector', () => {
     memoized(anotherObject)
     assert.equal(fallthroughs, 1, 'call with same object as previous call does not shallow compare')
   })
+  test('the subset will stay the same when the other parts of the whole collection changes.', () => {
+    function shallowEqual(newVal, oldVal) {
+      if (newVal === oldVal) return true
+
+      let countA = 0
+      let countB = 0
+      for (let key in newVal) {
+        if (Object.hasOwnProperty.call(newVal, key) && newVal[key] !== oldVal[key]) return false
+        countA++
+      }
+      for (let key in oldVal) {
+        if (Object.hasOwnProperty.call(oldVal, key)) countB++
+      }
+      return countA === countB
+    }
+
+    const a = {a: 1, filterType: 'a'}
+    const b = {b: 2, filterType: 'a'}
+    const c = {c: 3, filterType: 'b'}
+    const d = {};
+    Object.assign(d, c);
+    const arr1 = [a, b, c];
+    const arr2 = [a, b, d];
+
+    const createSelector = createSelectorCreator(defaultMemoize, shallowEqual)
+    const selector = createSelector(({list}) => list, (list) => list.filter((item) => item.filterType ==='a'));
+    const subset1 = selector({list: arr1});
+    const subset2 = selector({list: arr2});
+    assert.strictEqual(subset1, subset2);
+  })
   test('structured selector', () => { 
     const selector = createStructuredSelector({ 
       x: state => state.a,


### PR DESCRIPTION
There is one case, like below:
```
let arr = [a, b, c, d];

const selector = createSelector(
     arr => arr,
     (list) => list.filter((item) => item.type === 'a'));

const sub = selector({arr: arr});
```
we create a selector which is depend an array, and this selector will filter out the subset which type is `a`, but if the element of other type `b` has been changed, because the immutable, we will generate a new array, but the inner elements is the same as before except the changed one, so if we use the same selector it will output a new subset, but the inner element is same, so we want to use the cached subset at this time. we want to cut off the selectors change chain.
