### PR TITLE
Test to ensure inputSelectors called with same params as the selector

### DIFF
--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -23,7 +23,7 @@ suite('selector', () => {
     const firstState = { a: 1 }
     const firstStateNewPointer = { a: 1 }
     const secondState = { a: 2 }
-    
+
     assert.equal(selector(firstState), 1)
     assert.equal(selector(firstState), 1)
     assert.equal(selector.recomputations(), 1)
@@ -31,6 +31,13 @@ suite('selector', () => {
     assert.equal(selector.recomputations(), 1)
     assert.equal(selector(secondState), 2)
     assert.equal(selector.recomputations(), 2)
+  })
+  test('don\'t pass extra parameters to inputSelector when only called with the state', () => {
+    const selector = createSelector(
+      (...params) => params.length,
+      a => a
+    )
+    assert.equal(selector({}), 1)
   })
   test('basic selector multiple keys', () => {
     const selector = createSelector(


### PR DESCRIPTION
On master, the inputSelectors are called with an extra `undefined` param when the selector is only called with the state. This is usually not a problem, but in my specific case, some inputSelectors are curried functions, and in the result func, I use the returned function. I know it kind of defies the concept of `createSelector`, but in these cases, perf does not matter, and it lets me use the same API/patterns consistently in my app.

This bug is due to the `props` param (possibly undefined) passed to `dependency`, on this [line](https://github.com/reactjs/reselect/blob/master/src/index.js#L54).

I was planning to submit a fix, however, the 3.0.0 rewrite did fix this bug! So here is a test to prevent any regressions on this side :) If you add this test to master, you'll see that it breaks.

I can also submit this (with the corresponding fix) to the current master branch, if you think 3.0.0 won't be publish soon. I have no emergency on this, I can use a simple workaround on my side, it just makes my code a bit less readable!