### PR TITLE
Update Selector types for correct extension

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,18 +1,16 @@
 export as namespace Reselect;
 
-export interface Selector<S, R> {
-  (state: S): R;
-}
-export interface OutputSelector<S, R, C> extends Selector<S, R> {
+export type Selector<S, R> = (state: S) => R;
+
+export type OutputSelector<S, R, C> = Selector<S, R> & {
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;
 }
 
-export interface ParametricSelector<S, P, R> {
-  (state: S, props: P, ...args: any[]): R;
-}
-export interface OutputParametricSelector<S, P, R, C> extends ParametricSelector<S, P, R> {
+export type ParametricSelector<S, P, R> = (state: S, props: P, ...args: any[]) => R;
+
+export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> & {
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,13 +1,17 @@
 export as namespace Reselect;
 
-export type Selector<S, R> = (state: S) => R;
+export interface Selector<S, R> {
+  (state: S): R;
+}
 export interface OutputSelector<S, R, C> extends Selector<S, R> {
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;
 }
 
-export type ParametricSelector<S, P, R> = (state: S, props: P, ...args: any[]) => R;
+export interface ParametricSelector<S, P, R> {
+  (state: S, props: P, ...args: any[]): R;
+}
 export interface OutputParametricSelector<S, P, R, C> extends ParametricSelector<S, P, R> {
   resultFunc: C;
   recomputations: () => number;

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -34,6 +34,32 @@ function testSelector() {
   );
 }
 
+function testNestedSelector() {
+  type State = {foo: string, bar: number, baz: boolean};
+
+  const selector = createSelector(
+    createSelector(
+      (state: State) => state.foo,
+      (state: State) => state.bar,
+      (foo, bar) => ({foo, bar}),
+    ),
+    (state: State) => state.baz,
+    ({foo, bar}, baz) => {
+      const foo1: string = foo;
+      // typings:expect-error
+      const foo2: number = foo;
+
+      const bar1: number = bar;
+      // typings:expect-error
+      const bar2: string = bar;
+
+      const baz1: boolean = baz;
+      // typings:expect-error
+      const baz2: string = baz;
+    },
+  )
+}
+
 type Component<P> = (props: P) => any;
 
 declare function connect<S, P, R>(selector: ParametricSelector<S, P, R>):

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -60,6 +60,29 @@ function testNestedSelector() {
   )
 }
 
+function testSelectorAsCombiner() {
+  type SubState = {foo: string};
+  type State = {bar: SubState};
+
+  const subSelector = createSelector(
+    (state: SubState) => state.foo,
+    foo => foo,
+  );
+
+  const selector = createSelector(
+    (state: State) => state.bar,
+    subSelector,
+  );
+
+  // typings:expect-error
+  selector({foo: ''});
+
+  // typings:expect-error
+  const n: number = selector({bar: {foo: ''}});
+
+  const s: string = selector({bar: {foo: ''}});
+}
+
 type Component<P> = (props: P) => any;
 
 declare function connect<S, P, R>(selector: ParametricSelector<S, P, R>):


### PR DESCRIPTION
Fixes https://github.com/reactjs/reselect/issues/237.
This is backwards-compatible.