### PR TITLE
Add note about Redux props to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,9 @@ A: Yes. Reselect has no dependencies on any other package, so although it was de
 
 ### Q: How do I create a selector that takes an argument?
 
-A: Reselect doesn't have built-in support for creating selectors that accepts arguments, but here are some suggestions for implementing similar functionality...
+A: Keep in mind that selectors can access Redux props, so if your arguments are (or can be made available as) Redux props, you can use that functionality. [See here](#accessing-react-props-in-selectors) for details.
+
+Otherwise, Reselect doesn't have built-in support for creating selectors that accepts arguments, but here are some suggestions for implementing similar functionality...
 
 If the argument is not dynamic you can use a factory function:
 


### PR DESCRIPTION
The FAQ states that Reselect doesn't take additional arguments, but this doesn't cover the common scenario of those additional arguments being available as Redux props. (I needed a selector that took some additional arguments (which were available as Redux props), went straight to the FAQ (overlooking the "example" section), and saw an answer that I thought meant that I was out of luck. #162 seems to be from a user who followed a similar thought process.) This change hopefully clarifies things and adds an additional place to access this information.