### PR TITLE
Fixed typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,14 @@
 export as namespace Reselect;
 
 export type Selector<S, R> = (state: S) => R;
-export interface OutputSelector<S, R, C> extends Selector<S, R> {
+export type OutputSelector<S, R, C> = Selector<S, R> & {
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;
 }
 
 export type ParametricSelector<S, P, R> = (state: S, props: P, ...args: any[]) => R;
-export interface OutputParametricSelector<S, P, R, C> extends ParametricSelector<S, P, R> {
+export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> & {
   resultFunc: C;
   recomputations: () => number;
   resetRecomputations: () => number;


### PR DESCRIPTION
This does not compile

    export type Selector<S, R> = (state: S) => R;
    export interface OutputSelector<S, R, C> extends Selector<S, R> {
      resultFunc: C;
      recomputations: () => number;
      resetRecomputations: () => number;
    }

interfaces cannot extend types.

https://github.com/reactjs/reselect/blob/master/src/index.d.ts#L3-L8