### PR TITLE
Export composed selectors as dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
     selector.resultFunc = resultFunc
     selector.recomputations = () => recomputations
     selector.resetRecomputations = () => recomputations = 0
+    selector.dependencies = dependencies
     return selector
   }
 }

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -414,4 +414,15 @@ suite('selector', () => {
     )
     assert.equal(selector.resultFunc, lastFunction)
   })
+  test('export composed selectors as dependencies', () => {
+    const selectorA = (state) => state.a
+    const selectorB = (state) => state.b
+    const selector = createSelector(
+      selectorA,
+      selectorB,
+      (a, b) => a + b
+    )
+
+    assert.deepEqual([ selectorA, selectorB ], selector.dependencies)
+  })
 })


### PR DESCRIPTION
https://github.com/reactjs/reselect/issues/76

This PR will export the composed selector `dependencies`  as a property on the selector.  This will provide us the ability to test the selector dependencies as well as the `resultFunc`.