### PR TITLE
Add minified umd package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   },
   "scripts": {
     "compile:commonjs": "better-npm-run compile:commonjs",
+    "compile:umdmin": "uglifyjs dist/reselect.js -mt -o dist/reselect.min.js",
     "compile:umd": "better-npm-run compile:umd",
     "compile:es": "babel -d es/ src/",
-    "compile": "npm run compile:commonjs && npm run compile:umd && npm run compile:es",
+    "compile": "npm run compile:commonjs && npm run compile:umd && npm run compile:umdmin && npm run compile:es",
     "lint": "eslint src test",
     "prepublish": "npm run compile",
     "test": "better-npm-run test",
@@ -95,6 +96,7 @@
     "ncp": "^2.0.0",
     "nyc": "^6.4.0",
     "typescript": "^2.1.4",
-    "typings-tester": "^0.2.0"
+    "typings-tester": "^0.2.0",
+    "uglify-js": "^3.0.20"
   }
 }


### PR DESCRIPTION
First off, thanks for this library! It is the missing link between redux stores and view components and is absolutely fantastic!

Secondly, I realize unminifed, the library is like 4.6k, so this isn't a huge issue. I do think, though, as a best practice, all umd libs should provide both a minified and an unminified version of the code. As such, I've added uglify to compress the dist lib down to a minified version coming in at just over 2k.