### PR TITLE
Allow Differently Typed Selectors

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -953,8 +953,8 @@ export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12
 ): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
 
 
-export function defaultMemoize<F extends Function>(
-  func: F, equalityCheck?: <T>(a: T, b: T, index: number) => boolean,
+export function defaultMemoize<F extends Function, T>(
+  func: F, equalityCheck?: (a: T, b: T, index: number) => boolean,
 ): F;
 
 export function createSelectorCreator(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,559 +17,381 @@ export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> &
 }
 
 /* one selector */
-export function createSelector<S, R1, T>(
-  selector: Selector<S, R1>,
-  combiner: (res: R1) => T,
-): OutputSelector<S, T, (res: R1) => T>;
-export function createSelector<S, P, R1, T>(
-  selector: ParametricSelector<S, P, R1>,
-  combiner: (res: R1) => T,
-): OutputParametricSelector<S, P, T, (res: R1) => T>;
+export function createSelector<S1, R1, T>(
+  selector1: Selector<S1, R1>,
+  combiner: (res1: R1) => T,
+): OutputSelector<S1, T, (res1: R1) => T>;
+export function createSelector<S1, P1, R1, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  combiner: (res1: R1) => T,
+): OutputParametricSelector<S1, P1, T, (res1: R1) => T>;
 
-/* two selectors */
-export function createSelector<S, R1, R2, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
+/* two selector */
+export function createSelector<S1, S2, R1, R2, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
   combiner: (res1: R1, res2: R2) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2) => T>;
-export function createSelector<S, P, R1, R2, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
+): OutputSelector<S1 & S2, T, (res1: R1, res2: R2) => T>;
+export function createSelector<S1, S2, P1, P2, R1, R2, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
   combiner: (res1: R1, res2: R2) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2) => T>;
+): OutputParametricSelector<S1 & S2, P1 & P2, T, (res1: R1, res2: R2) => T>;
 
-/* three selectors */
-export function createSelector<S, R1, R2, R3, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
+/* three selector */
+export function createSelector<S1, S2, S3, R1, R2, R3, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
   combiner: (res1: R1, res2: R2, res3: R3) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3) => T>;
-export function createSelector<S, P, R1, R2, R3, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
+): OutputSelector<S1 & S2 & S3, T, (res1: R1, res2: R2, res3: R3) => T>;
+export function createSelector<S1, S2, S3, P1, P2, P3, R1, R2, R3, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
   combiner: (res1: R1, res2: R2, res3: R3) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3) => T>;
+): OutputParametricSelector<S1 & S2 & S3, P1 & P2 & P3, T, (res1: R1, res2: R2, res3: R3) => T>;
 
-/* four selectors */
-export function createSelector<S, R1, R2, R3, R4, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
+/* four selector */
+export function createSelector<S1, S2, S3, S4, R1, R2, R3, R4, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
+): OutputSelector<S1 & S2 & S3 & S4, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+export function createSelector<S1, S2, S3, S4, P1, P2, P3, P4, R1, R2, R3, R4, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+): OutputParametricSelector<S1 & S2 & S3 & S4, P1 & P2 & P3 & P4, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
 
-/* five selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
+/* five selector */
+export function createSelector<S1, S2, S3, S4, S5, R1, R2, R3, R4, R5, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
+): OutputSelector<S1 & S2 & S3 & S4 & S5, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+export function createSelector<S1, S2, S3, S4, S5, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5, P1 & P2 & P3 & P4 & P5, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
 
-/* six selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
+/* six selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, R1, R2, R3, R4, R5, R6, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6, P1 & P2 & P3 & P4 & P5 & P6, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
 
-/* seven selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
-  selector7: Selector<S, R7>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
-  selector7: ParametricSelector<S, P, R7>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T>;
+/* seven selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, R1, R2, R3, R4, R5, R6, R7, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
+  selector7: Selector<S7, R7>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, P1, P2, P3, P4, P5, P6, P7, R1, R2, R3, R4, R5, R6, R7, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
+  selector7: ParametricSelector<S7, P7, R7>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7, P1 & P2 & P3 & P4 & P5 & P6 & P7, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T>;
 
-/* eight selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
-  selector7: Selector<S, R7>,
-  selector8: Selector<S, R8>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
-  selector7: ParametricSelector<S, P, R7>,
-  selector8: ParametricSelector<S, P, R8>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T>;
+/* eight selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
+  selector7: Selector<S7, R7>,
+  selector8: Selector<S8, R8>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
+  selector7: ParametricSelector<S7, P7, R7>,
+  selector8: ParametricSelector<S8, P8, R8>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T>;
 
-/* nine selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
-  selector7: Selector<S, R7>,
-  selector8: Selector<S, R8>,
-  selector9: Selector<S, R9>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
-  selector7: ParametricSelector<S, P, R7>,
-  selector8: ParametricSelector<S, P, R8>,
-  selector9: ParametricSelector<S, P, R9>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T>;
+/* nine selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
+  selector7: Selector<S7, R7>,
+  selector8: Selector<S8, R8>,
+  selector9: Selector<S9, R9>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, P1, P2, P3, P4, P5, P6, P7, P8, P9, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
+  selector7: ParametricSelector<S7, P7, R7>,
+  selector8: ParametricSelector<S8, P8, R8>,
+  selector9: ParametricSelector<S9, P9, R9>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T>;
 
-/* ten selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
-  selector7: Selector<S, R7>,
-  selector8: Selector<S, R8>,
-  selector9: Selector<S, R9>,
-  selector10: Selector<S, R10>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
-  selector7: ParametricSelector<S, P, R7>,
-  selector8: ParametricSelector<S, P, R8>,
-  selector9: ParametricSelector<S, P, R9>,
-  selector10: ParametricSelector<S, P, R10>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+/* ten selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
+  selector7: Selector<S7, R7>,
+  selector8: Selector<S8, R8>,
+  selector9: Selector<S9, R9>,
+  selector10: Selector<S10, R10>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
+  selector7: ParametricSelector<S7, P7, R7>,
+  selector8: ParametricSelector<S8, P8, R8>,
+  selector9: ParametricSelector<S9, P9, R9>,
+  selector10: ParametricSelector<S10, P10, R10>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T>;
 
-/* eleven selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
-  selector7: Selector<S, R7>,
-  selector8: Selector<S, R8>,
-  selector9: Selector<S, R9>,
-  selector10: Selector<S, R10>,
-  selector11: Selector<S, R11>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
-  selector7: ParametricSelector<S, P, R7>,
-  selector8: ParametricSelector<S, P, R8>,
-  selector9: ParametricSelector<S, P, R9>,
-  selector10: ParametricSelector<S, P, R10>,
-  selector11: ParametricSelector<S, P, R11>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+/* eleven selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
+  selector7: Selector<S7, R7>,
+  selector8: Selector<S8, R8>,
+  selector9: Selector<S9, R9>,
+  selector10: Selector<S10, R10>,
+  selector11: Selector<S11, R11>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
+  selector7: ParametricSelector<S7, P7, R7>,
+  selector8: ParametricSelector<S8, P8, R8>,
+  selector9: ParametricSelector<S9, P9, R9>,
+  selector10: ParametricSelector<S10, P10, R10>,
+  selector11: ParametricSelector<S11, P11, R11>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
 
-/* twelve selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
-  selector1: Selector<S, R1>,
-  selector2: Selector<S, R2>,
-  selector3: Selector<S, R3>,
-  selector4: Selector<S, R4>,
-  selector5: Selector<S, R5>,
-  selector6: Selector<S, R6>,
-  selector7: Selector<S, R7>,
-  selector8: Selector<S, R8>,
-  selector9: Selector<S, R9>,
-  selector10: Selector<S, R10>,
-  selector11: Selector<S, R11>,
-  selector12: Selector<S, R12>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
-  selector1: ParametricSelector<S, P, R1>,
-  selector2: ParametricSelector<S, P, R2>,
-  selector3: ParametricSelector<S, P, R3>,
-  selector4: ParametricSelector<S, P, R4>,
-  selector5: ParametricSelector<S, P, R5>,
-  selector6: ParametricSelector<S, P, R6>,
-  selector7: ParametricSelector<S, P, R7>,
-  selector8: ParametricSelector<S, P, R8>,
-  selector9: ParametricSelector<S, P, R9>,
-  selector10: ParametricSelector<S, P, R10>,
-  selector11: ParametricSelector<S, P, R11>,
-  selector12: ParametricSelector<S, P, R12>,
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+/* twelve selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selector1: Selector<S1, R1>,
+  selector2: Selector<S2, R2>,
+  selector3: Selector<S3, R3>,
+  selector4: Selector<S4, R4>,
+  selector5: Selector<S5, R5>,
+  selector6: Selector<S6, R6>,
+  selector7: Selector<S7, R7>,
+  selector8: Selector<S8, R8>,
+  selector9: Selector<S9, R9>,
+  selector10: Selector<S10, R10>,
+  selector11: Selector<S11, R11>,
+  selector12: Selector<S12, R12>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selector1: ParametricSelector<S1, P1, R1>,
+  selector2: ParametricSelector<S2, P2, R2>,
+  selector3: ParametricSelector<S3, P3, R3>,
+  selector4: ParametricSelector<S4, P4, R4>,
+  selector5: ParametricSelector<S5, P5, R5>,
+  selector6: ParametricSelector<S6, P6, R6>,
+  selector7: ParametricSelector<S7, P7, R7>,
+  selector8: ParametricSelector<S8, P8, R8>,
+  selector9: ParametricSelector<S9, P9, R9>,
+  selector10: ParametricSelector<S10, P10, R10>,
+  selector11: ParametricSelector<S11, P11, R11>,
+  selector12: ParametricSelector<S12, P12, R12>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+
 
 
 /* array argument */
 
+
 /* one selector */
-export function createSelector<S, R1, T>(
-  selectors: [Selector<S, R1>],
-  combiner: (res: R1) => T,
-): OutputSelector<S, T, (res: R1) => T>;
-export function createSelector<S, P, R1, T>(
-  selectors: [ParametricSelector<S, P, R1>],
-  combiner: (res: R1) => T,
-): OutputParametricSelector<S, P, T, (res: R1) => T>;
+export function createSelector<S1, R1, T>(
+  selectors: [Selector<S1, R1>],
+  combiner: (res1: R1) => T,
+): OutputSelector<S1, T, (res1: R1) => T>;
+export function createSelector<S1, P1, R1, T>(
+  selectors: [ParametricSelector<S1, P1, R1>],
+  combiner: (res1: R1) => T,
+): OutputParametricSelector<S1, P1, T, (res1: R1) => T>;
 
-/* two selectors */
-export function createSelector<S, R1, R2, T>(
-  selectors: [Selector<S, R1>,
-              Selector<S, R2>],
+/* two selector */
+export function createSelector<S1, S2, R1, R2, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>],
   combiner: (res1: R1, res2: R2) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2) => T>;
-export function createSelector<S, P, R1, R2, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-              ParametricSelector<S, P, R2>],
+): OutputSelector<S1 & S2, T, (res1: R1, res2: R2) => T>;
+export function createSelector<S1, S2, P1, P2, R1, R2, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>],
   combiner: (res1: R1, res2: R2) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2) => T>;
+): OutputParametricSelector<S1 & S2, P1 & P2, T, (res1: R1, res2: R2) => T>;
 
-/* three selectors */
-export function createSelector<S, R1, R2, R3, T>(
-  selectors: [Selector<S, R1>,
-              Selector<S, R2>,
-              Selector<S, R3>],
+/* three selector */
+export function createSelector<S1, S2, S3, R1, R2, R3, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>],
   combiner: (res1: R1, res2: R2, res3: R3) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3) => T>;
-export function createSelector<S, P, R1, R2, R3, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-              ParametricSelector<S, P, R2>,
-              ParametricSelector<S, P, R3>],
+): OutputSelector<S1 & S2 & S3, T, (res1: R1, res2: R2, res3: R3) => T>;
+export function createSelector<S1, S2, S3, P1, P2, P3, R1, R2, R3, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>],
   combiner: (res1: R1, res2: R2, res3: R3) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3) => T>;
+): OutputParametricSelector<S1 & S2 & S3, P1 & P2 & P3, T, (res1: R1, res2: R2, res3: R3) => T>;
 
-/* four selectors */
-export function createSelector<S, R1, R2, R3, R4, T>(
-  selectors: [Selector<S, R1>,
-              Selector<S, R2>,
-              Selector<S, R3>,
-              Selector<S, R4>],
+/* four selector */
+export function createSelector<S1, S2, S3, S4, R1, R2, R3, R4, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>],
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-              ParametricSelector<S, P, R2>,
-              ParametricSelector<S, P, R3>,
-              ParametricSelector<S, P, R4>],
+): OutputSelector<S1 & S2 & S3 & S4, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+export function createSelector<S1, S2, S3, S4, P1, P2, P3, P4, R1, R2, R3, R4, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>],
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+): OutputParametricSelector<S1 & S2 & S3 & S4, P1 & P2 & P3 & P4, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
 
-/* five selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, T>(
-  selectors: [Selector<S, R1>,
-              Selector<S, R2>,
-              Selector<S, R3>,
-              Selector<S, R4>,
-              Selector<S, R5>],
+/* five selector */
+export function createSelector<S1, S2, S3, S4, S5, R1, R2, R3, R4, R5, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>],
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-              ParametricSelector<S, P, R2>,
-              ParametricSelector<S, P, R3>,
-              ParametricSelector<S, P, R4>,
-              ParametricSelector<S, P, R5>],
+): OutputSelector<S1 & S2 & S3 & S4 & S5, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+export function createSelector<S1, S2, S3, S4, S5, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>],
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5, P1 & P2 & P3 & P4 & P5, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
 
-/* six selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, T>(
-  selectors: [Selector<S, R1>,
-              Selector<S, R2>,
-              Selector<S, R3>,
-              Selector<S, R4>,
-              Selector<S, R5>,
-              Selector<S, R6>],
+/* six selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, R1, R2, R3, R4, R5, R6, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>],
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-              ParametricSelector<S, P, R2>,
-              ParametricSelector<S, P, R3>,
-              ParametricSelector<S, P, R4>,
-              ParametricSelector<S, P, R5>,
-              ParametricSelector<S, P, R6>],
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>],
   combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6, P1 & P2 & P3 & P4 & P5 & P6, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
 
-/* seven selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
-  selectors: [Selector<S, R1>,
-              Selector<S, R2>,
-              Selector<S, R3>,
-              Selector<S, R4>,
-              Selector<S, R5>,
-              Selector<S, R6>,
-              Selector<S, R7>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-              ParametricSelector<S, P, R2>,
-              ParametricSelector<S, P, R3>,
-              ParametricSelector<S, P, R4>,
-              ParametricSelector<S, P, R5>,
-              ParametricSelector<S, P, R6>,
-              ParametricSelector<S, P, R7>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7) => T>;
+/* seven selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, R1, R2, R3, R4, R5, R6, R7, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>, Selector<S7, R7>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, P1, P2, P3, P4, P5, P6, P7, R1, R2, R3, R4, R5, R6, R7, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>, ParametricSelector<S7, P7, R7>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7, P1 & P2 & P3 & P4 & P5 & P6 & P7, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7) => T>;
 
-/* eight selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
-  selectors: [Selector<S, R1>,
-    Selector<S, R2>,
-    Selector<S, R3>,
-    Selector<S, R4>,
-    Selector<S, R5>,
-    Selector<S, R6>,
-    Selector<S, R7>,
-    Selector<S, R8>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-    ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8) => T>;
+/* eight selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>, Selector<S7, R7>, Selector<S8, R8>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>, ParametricSelector<S7, P7, R7>, ParametricSelector<S8, P8, R8>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8) => T>;
 
-/* nine selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
-  selectors: [Selector<S, R1>,
-    Selector<S, R2>,
-    Selector<S, R3>,
-    Selector<S, R4>,
-    Selector<S, R5>,
-    Selector<S, R6>,
-    Selector<S, R7>,
-    Selector<S, R8>,
-    Selector<S, R9>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-    ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9) => T>;
+/* nine selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>, Selector<S7, R7>, Selector<S8, R8>, Selector<S9, R9>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, P1, P2, P3, P4, P5, P6, P7, P8, P9, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>, ParametricSelector<S7, P7, R7>, ParametricSelector<S8, P8, R8>, ParametricSelector<S9, P9, R9>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9) => T>;
 
-/* ten selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
-  selectors: [Selector<S, R1>,
-    Selector<S, R2>,
-    Selector<S, R3>,
-    Selector<S, R4>,
-    Selector<S, R5>,
-    Selector<S, R6>,
-    Selector<S, R7>,
-    Selector<S, R8>,
-    Selector<S, R9>,
-    Selector<S, R10>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-    ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>,
-    ParametricSelector<S, P, R10>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+/* ten selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>, Selector<S7, R7>, Selector<S8, R8>, Selector<S9, R9>, Selector<S10, R10>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>, ParametricSelector<S7, P7, R7>, ParametricSelector<S8, P8, R8>, ParametricSelector<S9, P9, R9>, ParametricSelector<S10, P10, R10>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10) => T>;
 
-/* eleven selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
-  selectors: [Selector<S, R1>,
-    Selector<S, R2>,
-    Selector<S, R3>,
-    Selector<S, R4>,
-    Selector<S, R5>,
-    Selector<S, R6>,
-    Selector<S, R7>,
-    Selector<S, R8>,
-    Selector<S, R9>,
-    Selector<S, R10>,
-    Selector<S, R11>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-    ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>,
-    ParametricSelector<S, P, R10>,
-    ParametricSelector<S, P, R11>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+/* eleven selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>, Selector<S7, R7>, Selector<S8, R8>, Selector<S9, R9>, Selector<S10, R10>, Selector<S11, R11>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>, ParametricSelector<S7, P7, R7>, ParametricSelector<S8, P8, R8>, ParametricSelector<S9, P9, R9>, ParametricSelector<S10, P10, R10>, ParametricSelector<S11, P11, R11>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
 
-/* twelve selectors */
-export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
-  selectors: [Selector<S, R1>,
-    Selector<S, R2>,
-    Selector<S, R3>,
-    Selector<S, R4>,
-    Selector<S, R5>,
-    Selector<S, R6>,
-    Selector<S, R7>,
-    Selector<S, R8>,
-    Selector<S, R9>,
-    Selector<S, R10>,
-    Selector<S, R11>,
-    Selector<S, R12>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
-): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
-export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
-  selectors: [ParametricSelector<S, P, R1>,
-    ParametricSelector<S, P, R2>,
-    ParametricSelector<S, P, R3>,
-    ParametricSelector<S, P, R4>,
-    ParametricSelector<S, P, R5>,
-    ParametricSelector<S, P, R6>,
-    ParametricSelector<S, P, R7>,
-    ParametricSelector<S, P, R8>,
-    ParametricSelector<S, P, R9>,
-    ParametricSelector<S, P, R10>,
-    ParametricSelector<S, P, R11>,
-    ParametricSelector<S, P, R12>],
-  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
-): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
-            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+/* twelve selector */
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selectors: [Selector<S1, R1>, Selector<S2, R2>, Selector<S3, R3>, Selector<S4, R4>, Selector<S5, R5>, Selector<S6, R6>, Selector<S7, R7>, Selector<S8, R8>, Selector<S9, R9>, Selector<S10, R10>, Selector<S11, R11>, Selector<S12, R12>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selectors: [ParametricSelector<S1, P1, R1>, ParametricSelector<S2, P2, R2>, ParametricSelector<S3, P3, R3>, ParametricSelector<S4, P4, R4>, ParametricSelector<S5, P5, R5>, ParametricSelector<S6, P6, R6>, ParametricSelector<S7, P7, R7>, ParametricSelector<S8, P8, R8>, ParametricSelector<S9, P9, R9>, ParametricSelector<S10, P10, R10>, ParametricSelector<S11, P11, R11>, ParametricSelector<S12, P12, R12>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
 
 
 export function defaultMemoize<F extends Function>(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -953,8 +953,8 @@ export function createSelector<S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, S12
 ): OutputParametricSelector<S1 & S2 & S3 & S4 & S5 & S6 & S7 & S8 & S9 & S10 & S11 & S12, P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10 & P11 & P12, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6, res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
 
 
-export function defaultMemoize<F extends Function, T>(
-  func: F, equalityCheck?: (a: T, b: T, index: number) => boolean,
+export function defaultMemoize<F extends Function>(
+  func: F, equalityCheck?: <T>(a: T, b: T, index: number) => boolean,
 ): F;
 
 export function createSelectorCreator(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> &
   resetRecomputations: () => number;
 }
 
-/* consistent selector parameter types */
+/* homogeneous selector parameter types */
 
 /* one selector */
 export function createSelector<S, R1, T>(
@@ -573,7 +573,7 @@ export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R1
 ): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
             res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
 
-/* inconsistent selector parameter types */
+/* heterogeneous selector parameter types */
 
 /* one selector */
 export function createSelector<S1, R1, T>(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,565 @@ export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> &
   resetRecomputations: () => number;
 }
 
+/* consistent selector parameter types */
+
+/* one selector */
+export function createSelector<S, R1, T>(
+  selector: Selector<S, R1>,
+  combiner: (res: R1) => T,
+): OutputSelector<S, T, (res: R1) => T>;
+export function createSelector<S, P, R1, T>(
+  selector: ParametricSelector<S, P, R1>,
+  combiner: (res: R1) => T,
+): OutputParametricSelector<S, P, T, (res: R1) => T>;
+
+/* two selectors */
+export function createSelector<S, R1, R2, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  combiner: (res1: R1, res2: R2) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2) => T>;
+export function createSelector<S, P, R1, R2, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  combiner: (res1: R1, res2: R2) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2) => T>;
+
+/* three selectors */
+export function createSelector<S, R1, R2, R3, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3) => T>;
+export function createSelector<S, P, R1, R2, R3, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3) => T>;
+
+/* four selectors */
+export function createSelector<S, R1, R2, R3, R4, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+
+/* five selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+
+/* six selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+
+/* seven selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  selector7: Selector<S, R7>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  selector7: ParametricSelector<S, P, R7>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T>;
+
+/* eight selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  selector7: Selector<S, R7>,
+  selector8: Selector<S, R8>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  selector7: ParametricSelector<S, P, R7>,
+  selector8: ParametricSelector<S, P, R8>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T>;
+
+/* nine selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  selector7: Selector<S, R7>,
+  selector8: Selector<S, R8>,
+  selector9: Selector<S, R9>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  selector7: ParametricSelector<S, P, R7>,
+  selector8: ParametricSelector<S, P, R8>,
+  selector9: ParametricSelector<S, P, R9>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T>;
+
+/* ten selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  selector7: Selector<S, R7>,
+  selector8: Selector<S, R8>,
+  selector9: Selector<S, R9>,
+  selector10: Selector<S, R10>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  selector7: ParametricSelector<S, P, R7>,
+  selector8: ParametricSelector<S, P, R8>,
+  selector9: ParametricSelector<S, P, R9>,
+  selector10: ParametricSelector<S, P, R10>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+
+/* eleven selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  selector7: Selector<S, R7>,
+  selector8: Selector<S, R8>,
+  selector9: Selector<S, R9>,
+  selector10: Selector<S, R10>,
+  selector11: Selector<S, R11>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  selector7: ParametricSelector<S, P, R7>,
+  selector8: ParametricSelector<S, P, R8>,
+  selector9: ParametricSelector<S, P, R9>,
+  selector10: ParametricSelector<S, P, R10>,
+  selector11: ParametricSelector<S, P, R11>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+
+/* twelve selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selector1: Selector<S, R1>,
+  selector2: Selector<S, R2>,
+  selector3: Selector<S, R3>,
+  selector4: Selector<S, R4>,
+  selector5: Selector<S, R5>,
+  selector6: Selector<S, R6>,
+  selector7: Selector<S, R7>,
+  selector8: Selector<S, R8>,
+  selector9: Selector<S, R9>,
+  selector10: Selector<S, R10>,
+  selector11: Selector<S, R11>,
+  selector12: Selector<S, R12>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selector1: ParametricSelector<S, P, R1>,
+  selector2: ParametricSelector<S, P, R2>,
+  selector3: ParametricSelector<S, P, R3>,
+  selector4: ParametricSelector<S, P, R4>,
+  selector5: ParametricSelector<S, P, R5>,
+  selector6: ParametricSelector<S, P, R6>,
+  selector7: ParametricSelector<S, P, R7>,
+  selector8: ParametricSelector<S, P, R8>,
+  selector9: ParametricSelector<S, P, R9>,
+  selector10: ParametricSelector<S, P, R10>,
+  selector11: ParametricSelector<S, P, R11>,
+  selector12: ParametricSelector<S, P, R12>,
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+
+
+/* array argument */
+
+/* one selector */
+export function createSelector<S, R1, T>(
+  selectors: [Selector<S, R1>],
+  combiner: (res: R1) => T,
+): OutputSelector<S, T, (res: R1) => T>;
+export function createSelector<S, P, R1, T>(
+  selectors: [ParametricSelector<S, P, R1>],
+  combiner: (res: R1) => T,
+): OutputParametricSelector<S, P, T, (res: R1) => T>;
+
+/* two selectors */
+export function createSelector<S, R1, R2, T>(
+  selectors: [Selector<S, R1>,
+              Selector<S, R2>],
+  combiner: (res1: R1, res2: R2) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2) => T>;
+export function createSelector<S, P, R1, R2, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+              ParametricSelector<S, P, R2>],
+  combiner: (res1: R1, res2: R2) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2) => T>;
+
+/* three selectors */
+export function createSelector<S, R1, R2, R3, T>(
+  selectors: [Selector<S, R1>,
+              Selector<S, R2>,
+              Selector<S, R3>],
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3) => T>;
+export function createSelector<S, P, R1, R2, R3, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+              ParametricSelector<S, P, R2>,
+              ParametricSelector<S, P, R3>],
+  combiner: (res1: R1, res2: R2, res3: R3) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3) => T>;
+
+/* four selectors */
+export function createSelector<S, R1, R2, R3, R4, T>(
+  selectors: [Selector<S, R1>,
+              Selector<S, R2>,
+              Selector<S, R3>,
+              Selector<S, R4>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+              ParametricSelector<S, P, R2>,
+              ParametricSelector<S, P, R3>,
+              ParametricSelector<S, P, R4>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4) => T>;
+
+/* five selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, T>(
+  selectors: [Selector<S, R1>,
+              Selector<S, R2>,
+              Selector<S, R3>,
+              Selector<S, R4>,
+              Selector<S, R5>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+              ParametricSelector<S, P, R2>,
+              ParametricSelector<S, P, R3>,
+              ParametricSelector<S, P, R4>,
+              ParametricSelector<S, P, R5>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5) => T>;
+
+/* six selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, T>(
+  selectors: [Selector<S, R1>,
+              Selector<S, R2>,
+              Selector<S, R3>,
+              Selector<S, R4>,
+              Selector<S, R5>,
+              Selector<S, R6>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+              ParametricSelector<S, P, R2>,
+              ParametricSelector<S, P, R3>,
+              ParametricSelector<S, P, R4>,
+              ParametricSelector<S, P, R5>,
+              ParametricSelector<S, P, R6>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6) => T>;
+
+/* seven selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, T>(
+  selectors: [Selector<S, R1>,
+              Selector<S, R2>,
+              Selector<S, R3>,
+              Selector<S, R4>,
+              Selector<S, R5>,
+              Selector<S, R6>,
+              Selector<S, R7>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+              ParametricSelector<S, P, R2>,
+              ParametricSelector<S, P, R3>,
+              ParametricSelector<S, P, R4>,
+              ParametricSelector<S, P, R5>,
+              ParametricSelector<S, P, R6>,
+              ParametricSelector<S, P, R7>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7) => T>;
+
+/* eight selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selectors: [Selector<S, R1>,
+    Selector<S, R2>,
+    Selector<S, R3>,
+    Selector<S, R4>,
+    Selector<S, R5>,
+    Selector<S, R6>,
+    Selector<S, R7>,
+    Selector<S, R8>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+    ParametricSelector<S, P, R2>,
+    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R8>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8) => T>;
+
+/* nine selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selectors: [Selector<S, R1>,
+    Selector<S, R2>,
+    Selector<S, R3>,
+    Selector<S, R4>,
+    Selector<S, R5>,
+    Selector<S, R6>,
+    Selector<S, R7>,
+    Selector<S, R8>,
+    Selector<S, R9>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+    ParametricSelector<S, P, R2>,
+    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R9>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9) => T>;
+
+/* ten selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selectors: [Selector<S, R1>,
+    Selector<S, R2>,
+    Selector<S, R3>,
+    Selector<S, R4>,
+    Selector<S, R5>,
+    Selector<S, R6>,
+    Selector<S, R7>,
+    Selector<S, R8>,
+    Selector<S, R9>,
+    Selector<S, R10>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+    ParametricSelector<S, P, R2>,
+    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R9>,
+    ParametricSelector<S, P, R10>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10) => T>;
+
+/* eleven selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selectors: [Selector<S, R1>,
+    Selector<S, R2>,
+    Selector<S, R3>,
+    Selector<S, R4>,
+    Selector<S, R5>,
+    Selector<S, R6>,
+    Selector<S, R7>,
+    Selector<S, R8>,
+    Selector<S, R9>,
+    Selector<S, R10>,
+    Selector<S, R11>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+    ParametricSelector<S, P, R2>,
+    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R9>,
+    ParametricSelector<S, P, R10>,
+    ParametricSelector<S, P, R11>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11) => T>;
+
+/* twelve selectors */
+export function createSelector<S, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selectors: [Selector<S, R1>,
+    Selector<S, R2>,
+    Selector<S, R3>,
+    Selector<S, R4>,
+    Selector<S, R5>,
+    Selector<S, R6>,
+    Selector<S, R7>,
+    Selector<S, R8>,
+    Selector<S, R9>,
+    Selector<S, R10>,
+    Selector<S, R11>,
+    Selector<S, R12>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputSelector<S, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+export function createSelector<S, P, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, T>(
+  selectors: [ParametricSelector<S, P, R1>,
+    ParametricSelector<S, P, R2>,
+    ParametricSelector<S, P, R3>,
+    ParametricSelector<S, P, R4>,
+    ParametricSelector<S, P, R5>,
+    ParametricSelector<S, P, R6>,
+    ParametricSelector<S, P, R7>,
+    ParametricSelector<S, P, R8>,
+    ParametricSelector<S, P, R9>,
+    ParametricSelector<S, P, R10>,
+    ParametricSelector<S, P, R11>,
+    ParametricSelector<S, P, R12>],
+  combiner: (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T,
+): OutputParametricSelector<S, P, T, (res1: R1, res2: R2, res3: R3, res4: R4, res5: R5, res6: R6,
+            res7: R7, res8: R8, res9: R9, res10: R10, res11: R11, res12: R12) => T>;
+
+/* inconsistent selector parameter types */
+
 /* one selector */
 export function createSelector<S1, R1, T>(
   selector1: Selector<S1, R1>,

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -26,7 +26,7 @@ function testSelector() {
   // typings:expect-error
   const num: number = selector({foo: 'bar'});
 
-  // typings:expect-error
+  // allows heterogeneous parameter type input selectors
   createSelector(
     (state: {foo: string}) => state.foo,
     (state: {bar: number}) => state.bar,
@@ -135,11 +135,61 @@ function testInvalidTypeInCombinator() {
     state => state.baz,
     (foo: string, bar: number, baz: boolean, fizz: string) => {}
   );
+
+  // does not allow heterogeneous parameter type
+  // selectors when the combinator function is typed differently
+  createSelector(
+    (state: {testString: string}) => state.testString,
+    (state: {testNumber: number}) => state.testNumber,
+    (state: {testBoolean: boolean}) => state.testBoolean,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testNumber: string}) => state.testNumber,
+    (state: {testStringArray: string[]}) => state.testStringArray,
+    // typings:expect-error
+    (foo1: string, foo2: number, foo3: boolean, foo4: string, foo5: string, foo6: string, foo7: string, foo8: number, foo9: string[]) => {
+      return {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9};
+    });
+
+  // does not allow a large array of heterogeneous parameter type
+  // selectors when the combinator function is typed differently
+  createSelector(
+    // typings:expect-error
+    [
+      (state: {testString: string}) => state.testString,
+      (state: {testNumber: number}) => state.testNumber,
+      (state: {testBoolean: boolean}) => state.testBoolean,
+      (state: {testString: string}) => state.testString,
+      (state: {testString: string}) => state.testString,
+      (state: {testString: string}) => state.testString,
+      (state: {testString: string}) => state.testString,
+      (state: {testNumber: string}) => state.testNumber,
+      (state: {testStringArray: string[]}) => state.testStringArray,
+    ], (foo1: string, foo2: number, foo3: boolean, foo4: string, foo5: string, foo6: string, foo7: string, foo8: number, foo9: string[]) => {
+      return {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9};
+    });
 }
 
 function testParametricSelector() {
   type State = {foo: string;};
   type Props = {bar: number};
+
+  // allows heterogeneous parameter type selectors
+  createSelector(
+    (state: {testString: string}) => state.testString,
+    (state: {testNumber: number}) => state.testNumber,
+    (state: {testBoolean: boolean}) => state.testBoolean,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testStringArray: string[]}) => state.testStringArray,
+    (foo1: string, foo2: number, foo3: boolean, foo4: string, foo5: string, foo6: string, foo7: string, foo8: string, foo9: string[]) => {
+      return {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9};
+    });
 
   const selector = createSelector(
     (state: State) => state.foo,
@@ -187,12 +237,6 @@ function testArrayArgument() {
   createSelector([
     (state: {foo: string}) => state.foo,
   ]);
-
-  // typings:expect-error
-  createSelector([
-    (state: {foo: string}) => state.foo,
-    (state: {bar: number}) => state.bar,
-  ], (foo, bar) => {});
 
   // typings:expect-error
   createSelector([
@@ -291,6 +335,22 @@ function testArrayArgument() {
   ], (bar: number, foo1: string, foo2: string, foo3: string, foo4: string,
       foo5: string, foo6: string, foo7: string, foo8: string) => {
     return {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, bar};
+  });
+
+  // allows a large array of heterogeneous parameter type selectors
+  const correctlyTypedArraySelector = createSelector([
+    (state: {testString: string}) => state.testString,
+    (state: {testNumber: number}) => state.testNumber,
+    (state: {testBoolean: boolean}) => state.testBoolean,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testString: string}) => state.testString,
+    (state: {testStringArray: string[]}) => state.testStringArray,
+  ], (foo1: string, foo2: number, foo3: boolean, foo4: string, foo5: string,
+      foo6: string, foo7: string, foo8: string, foo9: string[]) => {
+    return {foo1, foo2, foo3, foo4, foo5, foo6, foo7, foo8, foo9};
   });
 
   // typings:expect-error

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -424,6 +424,8 @@ function testCreateSelectorCreator() {
   // typings:expect-error
   createSelectorCreator(defaultMemoize, 1);
 
+  createSelectorCreator(defaultMemoize, (a: number, b: number) => a === b);
+
   createSelectorCreator(defaultMemoize, <T>(a: T, b: T, index: number) => {
     if (index === 0)
       return a === b;

--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -424,8 +424,6 @@ function testCreateSelectorCreator() {
   // typings:expect-error
   createSelectorCreator(defaultMemoize, 1);
 
-  createSelectorCreator(defaultMemoize, (a: number, b: number) => a === b);
-
   createSelectorCreator(defaultMemoize, <T>(a: T, b: T, index: number) => {
     if (index === 0)
       return a === b;

--- a/typescript_test/tsconfig.json
+++ b/typescript_test/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "noImplicitAny": true,
-    "strictNullChecks": true
+    "strict": true
   }
 }

--- a/typescript_test/tsconfig.json
+++ b/typescript_test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "strict": true
+    "noImplicitAny": true,
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
Here is the related issue https://github.com/reactjs/reselect/issues/264

Right now we have to do typings like this:

```
const selectorOne = (state: State) => state.something;
const selectorTwo = (state: State) => state.other;
createSelector([selectorOne, selectorTwo], () => ...);
```

This PR allows us to do typings like this:

```
const selectorOne = (state: { something: string }) => state.something;
const selectorTwo = (state: { other: number }) => state.other;
createSelector([selectorOne, selectorTwo], () => ...);
```

Let me know if I should change anything, thanks!
