### PR TITLE
chore: added `module` key to let modern bundlers pick ES version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Selectors for Redux.",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
+  "module": "es/index.js",
   "typings": "lib/index.d.ts",
   "files": [
     "lib",


### PR DESCRIPTION
`jsnext:main` is deprecated in favor of `module` key.
We can keep both to ensure the greatest compatibility with all bundlers.