### PR TITLE
Unexpected typescript result POC

### DIFF
--- a/typescript_test/test.ts
+++ b/typescript_test/test.ts
@@ -6,6 +6,39 @@ import {
   ParametricSelector,
 } from '../src/index';
 
+interface IHashTable<T> {
+  [key: string]: T | undefined;
+}
+const b: IHashTable<number> = {};
+
+const combinerNumber = (param: number) => param / 1;
+
+const selectorNumberOrUndefined = () => b['asdf'];
+function testNumberOrUndefined() {
+  // Why doesn't this error?
+  createSelector(
+    selectorNumberOrUndefined,
+    combinerNumber,
+  );
+
+  // This errors as expected
+  // Argument of type 'number | undefined' is not assignable to parameter of type 'number'. Type 'undefined' is not assignable to type 'number'.
+  combinerNumber(selectorNumberOrUndefined());
+}
+
+const selectorNumberOrString = () => b['asdf'] || 'mystring';
+function testNumberOrString() {
+  // Why doesn't this error?
+  createSelector(
+    selectorNumberOrString,
+    combinerNumber
+  );
+
+  // This errors as expected
+  // Argument of type 'number | "mystring"' is not assignable to parameter of type 'number'. Type '"mystring"' is not assignable to type 'number'.
+  combinerNumber(selectorNumberOrString());
+}
+
 function testSelector() {
   type State = {foo: string};
 


### PR DESCRIPTION
I've been working with reselect & typescript and just stumbled across a runtime error accessing a property on an undefined object. I would have thought typescript would have warned me, so I've created a simplified POC here. Please let me know if there's a better place to post this.

My question's are inline in the diff, but I'm wondering why `createSelector` doesn't complain that the types of the selector result and the combiner parameter do not match.

Thanks for the great library and for taking a look at this!