### PR TITLE
Fix grammatical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Simple “selector” library for Redux inspired by getters in [NuclearJS](https://github.com/optimizely/nuclear-js.git), [subscriptions](https://github.com/Day8/re-frame#just-a-read-only-cursor) in [re-frame](https://github.com/Day8/re-frame) and this [proposal](https://github.com/gaearon/redux/pull/169) from [speedskater](https://github.com/speedskater).
 
 * Selectors can compute derived data, allowing Redux to store the minimal possible state.
-* Selectors are efficient. A selector is not recomputed unless one of its arguments change.
+* Selectors are efficient. A selector is not recomputed unless one of its arguments changes.
 * Selectors are composable. They can be used as input to other selectors.
 
 ```js


### PR DESCRIPTION
The original verb, "change," does not agree with the subject, "one" (as opposed to, "arguments").

* Reference: Guideline number 5 on [Purdue University > ... > Grammar > Subject/Verb Agreement](https://owl.english.purdue.edu/owl/resource/599/01/)