### PR TITLE
Allow selector dependencies to be selector factories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,6 @@ function getDependencies(funcs) {
     )
   }
 
-  // return dependencies.map(dep => {
-  //   console.log('mapping dep ' + dep.length + ' ' + dep.toString());
-  //   return dep.length === 0 ? dep() : dep;
-  // })
   return dependencies
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,6 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
         if (typeof paramOrFactory === 'function') {
           // replace the dependency to avoid calling the factory again
           dependencies[i] = paramOrFactory
-
           params.push(paramOrFactory.apply(null, arguments))
         } else {
           params.push(paramOrFactory)

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,10 @@ function getDependencies(funcs) {
     )
   }
 
+  // return dependencies.map(dep => {
+  //   console.log('mapping dep ' + dep.length + ' ' + dep.toString());
+  //   return dep.length === 0 ? dep() : dep;
+  // })
   return dependencies
 }
 
@@ -71,7 +75,15 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
 
       for (let i = 0; i < length; i++) {
         // apply arguments instead of spreading and mutate a local list of params for performance.
-        params.push(dependencies[i].apply(null, arguments))
+        const paramOrFactory = dependencies[i].apply(null, arguments)
+        if (typeof paramOrFactory === 'function') {
+          // replace the dependency to avoid calling the factory again
+          dependencies[i] = paramOrFactory
+
+          params.push(paramOrFactory.apply(null, arguments))
+        } else {
+          params.push(paramOrFactory)
+        }
       }
 
       // apply arguments instead of spreading for performance.

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,8 +1,6 @@
-// TODO: Add test for React Redux connect function
-
-import chai from 'chai'
 import {  createSelector, createSelectorCreator, defaultMemoize, createStructuredSelector  } from '../src/index'
 import {  default as lodashMemoize  } from 'lodash.memoize'
+import chai from 'chai'
 
 const assert = chai.assert
 
@@ -43,15 +41,16 @@ suite('selector', () => {
     const selector = createSelector(
       state => state.a,
       state => state.b,
-      (a, b) => a + b
+      () => state => state.c,
+      (a, b, c) => a + b + c
     )
-    const state1 = { a: 1, b: 2 }
-    assert.equal(selector(state1), 3)
-    assert.equal(selector(state1), 3)
+    const state1 = { a: 1, b: 2, c: 3 }
+    assert.equal(selector(state1), 6)
+    assert.equal(selector(state1), 6)
     assert.equal(selector.recomputations(), 1)
-    const state2 = { a: 3, b: 2 }
-    assert.equal(selector(state2), 5)
-    assert.equal(selector(state2), 5)
+    const state2 = { a: 3, b: 4, c: 5 }
+    assert.equal(selector(state2), 12)
+    assert.equal(selector(state2), 12)
     assert.equal(selector.recomputations(), 2)
   })
   test('basic selector invalid input selector', () => {
@@ -353,14 +352,15 @@ suite('selector', () => {
   test('structured selector', () => {
     const selector = createStructuredSelector({
       x: state => state.a,
-      y: state => state.b
+      y: state => state.b,
+      z: () => state => state.c
     })
-    const firstResult = selector({ a: 1, b: 2 })
-    assert.deepEqual(firstResult, { x: 1, y: 2 })
-    assert.strictEqual(selector({ a: 1, b: 2 }), firstResult)
-    const secondResult = selector({ a: 2, b: 2 })
-    assert.deepEqual(secondResult, { x: 2, y: 2 })
-    assert.strictEqual(selector({ a: 2, b: 2 }), secondResult)
+    const firstResult = selector({ a: 1, b: 2, c: 3 })
+    assert.deepEqual(firstResult, { x: 1, y: 2, z: 3 })
+    assert.strictEqual(selector({ a: 1, b: 2, c: 3 }), firstResult)
+    const secondResult = selector({ a: 2, b: 2, c: 2 })
+    assert.deepEqual(secondResult, { x: 2, y: 2, z: 2 })
+    assert.strictEqual(selector({ a: 2, b: 2, c: 2 }), secondResult)
   })
   test('structured selector with invalid arguments', () => {
     assert.throw(() => createStructuredSelector(


### PR DESCRIPTION
As noted in the docs, if you are not careful, memoization can be undone when using a selector with props in multiple components.

The solution is to use a selector factory and pass that to mapStateToProps instead. This works well for one level deep selectors, however, if we are composing memoized selectors the same caveats apply. It is very easy to unintentionally be undoing all the memoization as we nest. The solution again is to keep wrapping our [sub-selectors in factories](http://jsbin.com/bohojakobo/1/edit?js,console) and executing them as we create the selectors.

A neater approach is to always accept either a selector or a selector factory in the createSelector function and handle it in a similar manner as react-redux connect does. This would allow us nest selector factories without having to explicitly execute the factory.




