### PR TITLE
Stop using expensive typeof in the production version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
 function getDependencies(funcs) {
   const dependencies = Array.isArray(funcs[0]) ? funcs[0] : funcs
 
-  if (!dependencies.every(dep => typeof dep === 'function')) {
+  if (process.env.NODE_ENV !== 'production' && !dependencies.every(dep => typeof dep === 'function')) {
     const dependencyTypes = dependencies.map(
       dep => typeof dep
     ).join(', ')
@@ -89,7 +89,7 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
 export const createSelector = /* #__PURE__ */ createSelectorCreator(defaultMemoize)
 
 export function createStructuredSelector(selectors, selectorCreator = createSelector) {
-  if (typeof selectors !== 'object') {
+  if (process.env.NODE_ENV !== 'production' && typeof selectors !== 'object') {
     throw new Error(
       'createStructuredSelector expects first argument to be an object ' +
       `where each property is a selector, instead received a ${typeof selectors}`


### PR DESCRIPTION
1. typeof is expensive

2. same as in libs like:
- React: https://github.com/facebook/react/blob/cae635054e17a6f107a39d328649137b83f25972/packages/react-dom/npm/index.js#L11
- React Redux: https://github.com/reduxjs/react-redux/blob/c695ff487ad28a048e16af931aa3a1e4b8109d1f/src/hooks/useReduxContext.ts#L24

3. production version of app has minified function names, so their listing will tell developer nothing, and the code will crash anyway