### PR TITLE
Additional 4.1 tweaks based on existing PRs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export function createSelectorCreator<
   // (memoize: MemoizeFunction, ...memoizeOptions: MemoizerOptions) {
   const createSelector = (...funcs: Function[]) => {
     let recomputations = 0
+    let lastResult: unknown
 
     // Due to the intricacies of rest params, we can't do an optional arg after `...funcs`.
     // So, start by declaring the default value here.
@@ -121,12 +122,14 @@ export function createSelectorCreator<
       }
 
       // apply arguments instead of spreading for performance.
-      return memoizedResultFunc.apply(null, params)
+      lastResult = memoizedResultFunc.apply(null, params)
+      return lastResult
     })
 
     selector.resultFunc = resultFunc
     selector.memoizedResultFunc = memoizedResultFunc
     selector.dependencies = dependencies
+    selector.lastResult = () => lastResult
     selector.recomputations = () => recomputations
     selector.resetRecomputations = () => (recomputations = 0)
     return selector

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,10 @@ export type Selector<
   P extends never | readonly any[] = any[]
 > = [P] extends [never] ? (state: S) => R : (state: S, ...params: P) => R
 
-interface OutputSelectorFields<Combiner> {
+interface OutputSelectorFields<Combiner, Result> {
   resultFunc: Combiner
   memoizedResultFunc: Combiner
+  lastResult: () => Result
   dependencies: SelectorArray
   recomputations: () => number
   resetRecomputations: () => number
@@ -18,12 +19,17 @@ export type OutputSelector<
   Params extends readonly any[],
   Combiner
 > = Selector<GetStateFromSelectors<S>, Result, Params> &
-  OutputSelectorFields<Combiner>
+  OutputSelectorFields<Combiner, Result>
 
-export type ParametricSelector<S, P, R> = Selector<S, R, [P, ...any]>
+export type ParametricSelector<State, Props, Result> = Selector<
+  State,
+  Result,
+  [Props, ...any]
+>
 
-export type OutputParametricSelector<S, P, R, C> = ParametricSelector<S, P, R> &
-  OutputSelectorFields<C>
+export type OutputParametricSelector<State, Props, Result, Combiner> =
+  ParametricSelector<State, Props, Result> &
+    OutputSelectorFields<Combiner, Result>
 
 export type SelectorArray = ReadonlyArray<Selector>
 

--- a/test/test_selector.ts
+++ b/test/test_selector.ts
@@ -730,4 +730,16 @@ describe('createSelector exposed utils', () => {
     const selector = createSelector(dependency1, dependency2, () => {})
     expect(selector.dependencies).toEqual([dependency1, dependency2])
   })
+
+  test('export lastResult function', () => {
+    const selector = createSelector(
+      (state: StateAB) => state.a,
+      (state: StateAB) => state.b,
+      (a, b) => a + b
+    )
+
+    const result = selector({ a: 1, b: 2 })
+    expect(result).toBe(3)
+    expect(selector.lastResult()).toBe(3)
+  })
 })


### PR DESCRIPTION
This PR:

- Adds an error message if `resultFunc` isn't a function
- Improves the error message for bad dependency args
- Includes `memoizedResultFunc` and `lastResult` in the util fields of the selector

Fixes #350 
Fixes #404 

Supersedes #358 , #359, #405 , #448 .