### PR TITLE
Fix leaking Ref in weakMapMemoize

### DIFF
--- a/src/weakMapMemoize.ts
+++ b/src/weakMapMemoize.ts
@@ -97,6 +97,20 @@ export interface WeakMapMemoizeOptions<Result = any> {
 }
 
 /**
+ * Derefences the argument if it is a Ref. Else if it is a value already, return it.
+ *
+ * @param r - the object to maybe deref
+ * @returns The derefenced value if the argument is a Ref, else the argument value itself.
+ */
+function maybeDeref(r: any) {
+  if (r instanceof Ref) {
+    return r.deref()
+  }
+
+  return r
+}
+
+/**
  * Creates a tree of `WeakMap`-based cache nodes based on the identity of the
  * arguments it's been called with (in this case, the extracted values from your input selectors).
  * This allows `weakMapMemoize` to have an effectively infinite cache size.
@@ -229,7 +243,8 @@ export function weakMapMemoize<Func extends AnyFunction>(
       resultsCount++
 
       if (resultEqualityCheck) {
-        const lastResultValue = lastResult?.deref?.() ?? lastResult
+        // Deref lastResult if it is a Ref
+        const lastResultValue = maybeDeref(lastResult)
 
         if (
           lastResultValue != null &&


### PR DESCRIPTION
This PR contains the following changes:
- Update the dereference logic in `weakMapMemoize.ts` to check if the `lastResult` is a `Ref` before dereferencing it.

### Context:
The previous code could leak a `WeakRef` if the dereferenced value was `undefined` (which I think happens when the original object is forcefully garbage collected):
Let `lastResult` be a `Ref` to `undefined`:
```
const lastResultValue = lastResult?.deref?.() ?? lastResult
-> const lastResultValue = lastResult.deref() ?? lastResult
-> const lastResultValue = undefined ?? lastResult`
-> const lastResultValue = lastResult (= Ref{undefined})
```

With this new change, we will return the new value (even when the old garbage collected value would've passed the `resultEqualityCheck` and would've been memoized).

I chose the `instanceof` check because `Ref` is defined above as a `WeakRef` if it is available, else it is a `StrongRef` which is a locally defined class.

I tried to add a unit test which reproduced the issue by garbage collecting values in the cache so they would be `Ref`s to `undefined`, but I didn't have any luck. I followed a similar strategy to [this test](https://github.com/reduxjs/reselect/blob/master/test/perfComparisons.spec.ts#L286) by using a `FinalizationRegistry`. I also tried a test which `unmount`ed a React component containing the original state. Please let me know if you have any ideas for this unit test :)

### (aside) How we discovered the issue:
- We had an array in a React component, which was then fed into a chain of selectors (of which the last returned a `weakMapMemoized` array).
- This component got unmounted, and the cached `weakMapMemoized` result got garbage collected.
- The next caller of this same selector produced an empty array result.
- This passed our `shallowEquals` `resultEqualityCheck` (`Object.keys(WeakRef{undefined})` == `Object.keys([])` == `[]`)
- This leaked the `WeakRef` into the code which expected an array, and caused an exception.