### PR TITLE
Bump arethetypeswrong CLI to 0.18.3 to fix fflate tarball crash

### DIFF
--- a/.github/workflows/build-and-test-types.yml
+++ b/.github/workflows/build-and-test-types.yml
@@ -126,7 +126,7 @@ jobs:
 
       # Note: We currently expect "FalseCJS" failures for Node16 + `moduleResolution: "node16",
       - name: Run are-the-types-wrong
-        run: npx @arethetypeswrong/cli@0.18.2 ./package.tgz --format table --ignore-rules false-cjs
+        run: npx @arethetypeswrong/cli@0.18.3 ./package.tgz --format table --ignore-rules false-cjs
 
   test-published-artifact:
     name: Test Published Artifact ${{ matrix.example }}


### PR DESCRIPTION
# Fix `are-the-types-wrong` CI failure

The `are-the-types-wrong` job started failing on every PR with `Cannot read properties of undefined (reading 'filename')`, even on branches that don't touch anything type-related. It's not caused by any of our changes.

The workflow pins the CLI itself (`@arethetypeswrong/cli@0.18.2`), but its transitive `fflate` dependency is a caret range, so `npx` pulls in a fresh copy on every run. When `fflate@0.8.3` was published, `0.18.2` picked it up and its tarball parsing broke, which is why the failure showed up across all open PRs at once rather than in one branch.

The fix landed upstream in `0.18.3` — its changelog literally reads "Fix 'Cannot read properties of undefined (reading 'filename')' caused by fflate 0.8.3". Bumping the pinned version to `0.18.3` restores a working `fflate` and gets CI green again.
